### PR TITLE
fix: Fix Path Resolution in `process_log_dir_replacements` Function

### DIFF
--- a/kai/kai_logging.py
+++ b/kai/kai_logging.py
@@ -18,7 +18,7 @@ def process_log_dir_replacements(log_dir: str) -> str:
     ##
     if log_dir.startswith("$pwd"):
         current_directory = os.getcwd()
-        kai_project_directory = os.path.abspath(os.path.join(current_directory, ".."))
+        kai_project_directory = os.path.abspath(current_directory)
         log_dir = log_dir.replace("$pwd", kai_project_directory, 1)
         log_dir = os.path.normpath(log_dir)
     return log_dir

--- a/kai/kai_logging.py
+++ b/kai/kai_logging.py
@@ -11,15 +11,16 @@ formatter = logging.Formatter(
 )
 
 
-def process_log_dir_replacements(log_dir: str):
+def process_log_dir_replacements(log_dir: str) -> str:
     ##
     # We want to replace $pwd with the location of the Kai project directory,
     # this is needed to help with specifying from configuration
     ##
     if log_dir.startswith("$pwd"):
-        log_dir = log_dir.replace(
-            "$pwd", os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
-        )
+        current_directory = os.getcwd()
+        kai_project_directory = os.path.abspath(os.path.join(current_directory, ".."))
+        log_dir = log_dir.replace("$pwd", kai_project_directory, 1)
+        log_dir = os.path.normpath(log_dir)
     return log_dir
 
 


### PR DESCRIPTION
## Summary
This PR closes #278. It addresses an issue with the `process_log_dir_replacements` function, which is responsible for replacing the $pwd placeholder in log directory paths with the path to the Kai project directory. The original function returned paths with redundant components and did not correctly resolve relative paths.

## Issue
The original function produced paths with incorrect or redundant components, such as /home/k8smaster/Desktop/kai/kai/..//logs, leading to errors and misconfiguration in the log directory paths.

## Changes Made
Function Update: Updated the process_log_dir_replacements function to:
Replace $pwd with the path to the Kai project directory, one level up from the current working directory.
Normalize the resulting path to remove redundant components and resolve relative path issues.
```
def process_log_dir_replacements(log_dir: str) -> str:
    ##
    # We want to replace $pwd with the location of the Kai project directory,
    # this is needed to help with specifying from configuration
    ##
    if log_dir.startswith("$pwd"):
        current_directory = os.getcwd()
        kai_project_directory = os.path.abspath(os.path.join(current_directory, ".."))
        log_dir = log_dir.replace("$pwd", kai_project_directory, 1)
        log_dir = os.path.normpath(log_dir)
    return log_dir
```
