### PR TITLE
Fix type annotation in print_nicely_formatted_comparison function

### DIFF
--- a/kai/evaluation.py
+++ b/kai/evaluation.py
@@ -257,7 +257,7 @@ def evaluate(
     return overall_results
 
 
-def print_nicely_formatted_comparison(results: dict[tuple[str, str], BenchmarkExample]):
+def print_nicely_formatted_comparison(results: dict[tuple[str, str], BenchmarkResult]):
     print(f'{"Example Name"}\t{"Config Name"}\t{"Benchmark Result"}')
 
     for (example_name, config_name), benchmark_result in results.items():


### PR DESCRIPTION
This PR addresses an inconsistency in the type annotation of the `print_nicely_formatted_comparison` function in `evaluation.py`.

Changes made:
- Updated the type hint for the `results` parameter from `dict[tuple[str, str], BenchmarkExample]` to `dict[tuple[str, str], BenchmarkResult]`

Reason for change:
The function was accessing a `similarity` attribute which is present in `BenchmarkResult` but not in `BenchmarkExample`. This change aligns the type annotation with the actual usage in the function, preventing potential runtime errors and improving type checking.

Related issue: closes #290 

Please review and let me know if any further changes are needed.