### PR TITLE
Fixes blocking Kai integration

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -40,5 +40,5 @@ if [[ ${MODE} != "importer" ]]; then
 	PYTHONPATH="/kai/kai" exec gunicorn --timeout 3600 -w "${NUM_WORKERS}" --bind 0.0.0.0:8080 --worker-class aiohttp.GunicornWebWorker 'kai.server:app()'
 else
 	cd /kai || exit
-	python ./kai/hub_importer.py --loglevel "${LOGLEVEL}" --config_filepath ./kai/config.toml "${IMPORTER_ARGS}" "${HUB_URL}"
+	python ./kai/hub_importer.py --loglevel "${LOGLEVEL}" --config_filepath ./kai/config.toml "${HUB_URL}" "${IMPORTER_ARGS}"
 fi

--- a/kai/hub_importer.py
+++ b/kai/hub_importer.py
@@ -332,7 +332,11 @@ def process_analyses(
             }
         if report_data:
             reports.append(
-                (application, credentials, Report.load_report_from_object(report_data))
+                (
+                    application,
+                    credentials,
+                    Report.load_report_from_object(report_data, analysis.id),
+                )
             )
     return reports
 


### PR DESCRIPTION
- [🐛 When importer args aren't provided, don't use empty string as url](https://github.com/konveyor/kai/pull/309/commits/a4625184262c310e7d78da9029e13bb5a82599a2)
- [🐛 Pass analysis ID in when report is loaded](https://github.com/konveyor/kai/pull/309/commits/52a1731817a33deb969e036c99524c1b43cdd1c8)