### PR TITLE
🐛 Address URL encoding for source code sent to LLM 

### DIFF
--- a/kai/data/templates/main.jinja
+++ b/kai/data/templates/main.jinja
@@ -26,7 +26,7 @@ After you have shared your step by step thinking, provide a full output of the u
 File name: "{{ src_file_name }}"
 Source file contents:
 ```{{ src_file_language }}
-{{ src_file_contents | urlencode }} ##use jinja filter urlencode 
+{{ src_file_contents | safe }} 
 ```
 
 ## Issues

--- a/kai/data/templates/main.jinja
+++ b/kai/data/templates/main.jinja
@@ -26,7 +26,7 @@ After you have shared your step by step thinking, provide a full output of the u
 File name: "{{ src_file_name }}"
 Source file contents:
 ```{{ src_file_language }}
-{{ src_file_contents }}
+{{ src_file_contents | urlencode }} ##use jinja filter urlencode 
 ```
 
 ## Issues


### PR DESCRIPTION
Addresses #213 by applying the `| urlencode` filter to the src_file_contents variable in main.jinja. 

### Testing:
Ran `example/run_demo.py` with the modified main.jinja file to verify that the LLM is receiving the source code correctly and processing it as expected.

Signed-off-by: Anushka Saxena <anushkasaxena.1947@gmail.com>