### PR TITLE
:bug: fix Kai client's build spec for Windows

### DIFF
--- a/playpen/README.md
+++ b/playpen/README.md
@@ -12,6 +12,7 @@ The goals of this effort are:
 As of writing this, here's the progress we made on the goals above:
 
 - We have a JSON-RPC interface in front of the Client CLI. The JSON-RPC interface can be found in [./client/rpc.py](./client/rpc.py). It exposes `get_incident_solutions_for_file` function that generates a fix for one file. There are two example clients (Python and Javascript) we have written that talk with the interface over I/O streams.
+
 - We have a `build.spec` file that builds the JSON-RPC client into a binary using PyInstaller.
 
 ### Building JSON-RPC interface into a binary
@@ -35,6 +36,12 @@ pyinstaller build.spec
 ```
 
 Once successful, a binary will be generated at `./dist/cli`.
+
+#### Building for different platforms
+
+We are using PyInstaller to create binaries. To create a binary for a certain platform / arch, we are building on the same platform + arch. As per our understanding, it is possible to potentially cross-compile for different architectures but not the platform itself.
+
+So far, we have successfully built and tested binaries for MacOS and Windows (built on respective machines).
 
 ### Testing JSON-RPC binary
 

--- a/playpen/build.spec
+++ b/playpen/build.spec
@@ -18,7 +18,7 @@ script_path = 'client/rpc.py'
 
 a = Analysis(
     [script_path],
-    pathex=[os.path.dirname(script_path)],
+    pathex=[os.path.dirname(script_path), '../'],
     binaries=[],
     datas=data_dirs,
     hiddenimports=["_ssl"],

--- a/playpen/rpc-client.py
+++ b/playpen/rpc-client.py
@@ -53,6 +53,9 @@ def main():
         )
         print(response)
         print("\nReceived response successfully!")
+    except Exception as e:
+        print(str(e))
+        print("\nFailed to generate fix")
     finally:
         rpc_server.stdin.close()
         rpc_server.stdout.close()


### PR DESCRIPTION
This also addresses a bug in JSON decoder caused due to differences in default encoding on Windows. Now we don't have to worry about default encoding as we are not reading strings anymore but using the bytes directly and enforcing utf-8 encoding explicitly.

```
gaikw@pranav MINGW64 /e/Projects/kai/playpen (main)
$ python rpc-client.py /e/Projects/kai/kai/config.toml coolstore /e/Projects/kai/notebooks/evaluation/analysis_output.yaml /e/Projects/coolstore/src/main/java/com/redhat/coolstore/service/CatalogService.java
running get_incident_solutions_for_file() with params {'config_path': 'E:/Projects/kai/kai/config.toml', 'app_name': 'coolstore', 'report_path': 'E:/Projects/kai/notebooks/evaluation/analysis_output.yaml', 'input_file_path': 'E:/Projects/coolstore/src/main/java/com/redhat/coolstore/service/CatalogService.java'}
package com.redhat.coolstore.service;

import java.util.List;
import java.util.logging.Logger;

import jakarta.inject.Inject;

import jakarta.persistence.criteria.CriteriaBuilder;
import jakarta.persistence.criteria.CriteriaQuery;
import jakarta.persistence.criteria.Root;

import jakarta.ejb.ApplicationScoped;
import jakarta.persistence.EntityManager;

import com.redhat.coolstore.model.*;

@ApplicationScoped
public class CatalogService {

    @Inject
    Logger log;

    @Inject
    private EntityManager em;

    public CatalogService() {
    }

    public List<CatalogItemEntity> getCatalogItems() {
        CriteriaBuilder cb = em.getCriteriaBuilder();
        CriteriaQuery<CatalogItemEntity> criteria = cb.createQuery(CatalogItemEntity.class);
        Root<CatalogItemEntity> member = criteria.from(CatalogItemEntity.class);
        criteria.select(member);
        return em.createQuery(criteria).getResultList();
    }

    public CatalogItemEntity getCatalogItemById(String itemId) {
        return em.find(CatalogItemEntity.class, itemId);
    }

    public void updateInventoryItems(String itemId, int deducts) {
        InventoryEntity inventoryEntity = getCatalogItemById(itemId).getInventory();
        int currentQuantity = inventoryEntity.getQuantity();
        inventoryEntity.setQuantity(currentQuantity-deducts);
        em.merge(inventoryEntity);
    }

}


Received response successfully!
(venv)
```

