### PR TITLE
Add metadata to tracing

### DIFF
--- a/kai/kai_trace.py
+++ b/kai/kai_trace.py
@@ -139,6 +139,20 @@ class KaiTrace:
             f.write(result.pretty_repr())
 
     @enabled_check
+    def llm_token_usage(
+        self, current_batch_count: int, retry_count: int, token_usage: dict
+    ):
+        token_usage_file_path = os.path.join(
+            self.trace_dir,
+            f"{current_batch_count}",
+            f"{retry_count}",
+            "token_usage.json",
+        )
+        os.makedirs(os.path.dirname(token_usage_file_path), exist_ok=True)
+        with open(token_usage_file_path, "w") as f:
+            f.write(json.dumps(token_usage, indent=4, default=str))
+
+    @enabled_check
     def exception(
         self,
         current_batch_count: int,

--- a/kai/service/kai_application/kai_application.py
+++ b/kai/service/kai_application/kai_application.py
@@ -180,6 +180,15 @@ class KaiApplication:
                     ):
                         llm_result = self.model_provider.llm.invoke(prompt)
                         trace.llm_result(count, retry_attempt_count, llm_result)
+                        try:
+                            token_usage = llm_result.response_metadata["token_usage"]
+                            trace.llm_token_usage(
+                                count, retry_attempt_count, token_usage
+                            )
+                        except KeyError as e:
+                            KAI_LOG.warning(
+                                f"Key does not exist in the dictionary: {e}"
+                            )
 
                         content = parse_file_solution_content(
                             src_file_language, str(llm_result.content)


### PR DESCRIPTION
**Capture Number of Tokens in Request and Response**
When this PR is merged, you will be able to capture metadata from the responses into the trace directory when you run [run_demo.py](https://github.com/konveyor/kai/blob/main/example/run_demo.py) . The structure will be as follows:
```bash
── trace
      └── gpt-3.5-turbo << MODEL ID>>
          └── coolstore << APP Name >>
              ├── pom.xml << Source File Path >>
              │   └── single_group << Incident Batch Mode >>
              │       └── 1719673609.8266618 << Start of Request Time Stamp >>
              │           ├── 1 << Incident Batch Number >>
              │           │   ├── 0 << Retry Attempt  >>
              │           │   │   ├── llm_result << Contains the response from the LLM prior to us parsing >>
              │           │   │   ├── token_usage.json<< New metadata file added here >>
              │           │   │   ├── prompt << The formatted prompt prior to sending to LLM >>
              │           │   │   └── prompt_vars.json << The prompt variables which are injected into the prompt template >>
              │           │   ├── params.json << Request parameters >>
              │           │   └── timing << Duration of a Successful Request >>
              └── src
                  └── main
                      ├── java
                      │   └── com
                      │       └── redhat
                      │           └── coolstore
                      │               ├── model
                      │               │   ├── InventoryEntity.java
                      │               │   │   └── single_group
                      │               │   │       └── 1719673609.827135
                      │               │   │           ├── 1
                      │               │   │           │   ├── 0
                      │               │   │           │   │   ├── llm_result
                      │               │   │           │   │   └── token_usage.json << New metadata file added here >>
                      │               │   │           │   ├── prompt
                      │               │   │           │   └── prompt_vars.json
                      │               │   │           ├── params.json
                      │               │   │           └── timing
                      │               │   ├── Order.java
                      │               │   │   └── single_group
                      │               │   │       └── 1719673609.826999
                      │               │   │           ├── 1
                      │               │   │           │   ├── 0
                      │               │   │           │   │   ├── llm_result
                      │               │   │           │   │   └── token_usage.json << New metadata file added here >>
                      │               │   │           │   ├── prompt
                      │               │   │           │   └── prompt_vars.json
                      │               │   │           ├── params.json
                      │               │   │           └── timing

```
This will aid you in debugging by providing detailed metadata and trace information.

**Note**: The metadata captured varies across different models. This variation reflects the unique characteristics and capabilities of each model, such as token usage, latency, or other performance metrics. For specific details on the metadata differences across various models, please refer to the following link: [LLM Metadata Variations](https://python.langchain.com/v0.1/docs/modules/model_io/chat/response_metadata/).