### PR TITLE
Change from token_usage to all response metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ POSTGRES_RUN_ARGS ?=
 run-postgres:
 	$(CONTAINER_RUNTIME) run -it $(POSTGRES_RUN_ARGS) -v data:/var/lib/postgresql/data -e POSTGRES_USER=kai -e POSTGRES_PASSWORD=dog8code -e POSTGRES_DB=kai -p 5432:5432 docker.io/library/postgres:16.3
 
+# ## Note: MacOS workaround is required, see https://github.com/konveyor/kai/issues/374
 run-server:
 	bash -c 'set -m; _trap () { kill -15 $$PID; } ; trap _trap SIGINT ;\
 	if [[ "$$(uname)" -eq "Darwin" ]] ; then export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ; fi ;\

--- a/example/run_demo.py
+++ b/example/run_demo.py
@@ -128,6 +128,18 @@ def write_to_disk(file_path: Path, updated_file_contents: dict):
         KAI_LOG.error(f"Contents: {updated_file_contents}")
         sys.exit(1)
 
+    llm_response_metadata_path = f"{intended_file_path}.llm_response_metadata.json"
+    KAI_LOG.info(f"Writing llm_response_metadata to {llm_response_metadata_path}")
+    try:
+        with open(llm_response_metadata_path, "w") as f:
+            json.dump(updated_file_contents["response_metadatas"], f)
+    except Exception as e:
+        KAI_LOG.error(
+            f"Failed to write llm_response_metadata @ {llm_response_metadata_path} with error: {e}"
+        )
+        KAI_LOG.error(f"Contents: {updated_file_contents}")
+        sys.exit(1)
+
     # since the other files are all contained within the llm_result, avoid duplication
     # when they're available
     if updated_file_contents.get("llm_results"):

--- a/kai/kai_trace.py
+++ b/kai/kai_trace.py
@@ -139,18 +139,18 @@ class KaiTrace:
             f.write(result.pretty_repr())
 
     @enabled_check
-    def llm_token_usage(
-        self, current_batch_count: int, retry_count: int, token_usage: dict
+    def response_metadata(
+        self, current_batch_count: int, retry_count: int, response_metadata: dict
     ):
-        token_usage_file_path = os.path.join(
+        response_metadata_file_path = os.path.join(
             self.trace_dir,
             f"{current_batch_count}",
             f"{retry_count}",
-            "token_usage.json",
+            "response_metadata.json",
         )
-        os.makedirs(os.path.dirname(token_usage_file_path), exist_ok=True)
-        with open(token_usage_file_path, "w") as f:
-            f.write(json.dumps(token_usage, indent=4, default=str))
+        os.makedirs(os.path.dirname(response_metadata_file_path), exist_ok=True)
+        with open(response_metadata_file_path, "w") as f:
+            f.write(json.dumps(response_metadata, indent=4, default=str))
 
     @enabled_check
     def exception(


### PR DESCRIPTION
This is builds on #375.

I saw while testing that not all providers sent back the same keys in 'response_metadata'.
For example Bedrock has the key 'usage' and IBM BAM and Groq have the key 'token_usage'.

To keep things simple, I'm proposing we log all response_metadata to disk and not look for a specific key.

This PR also updates the server to send back the responses metadata in it's result so the client can access it.

