### PR TITLE
Integration of Token Estimation for Input Prompts

### DIFF
--- a/kai/config.toml
+++ b/kai/config.toml
@@ -6,6 +6,7 @@ file_log_level = "debug"
 log_dir = "$pwd/logs"
 demo_mode = false
 trace_enabled = true
+token_estimation_encoding_base = "gpt-4o"
 
 solution_consumers = ["diff_only", "llm_summary"]
 

--- a/kai/kai_trace.py
+++ b/kai/kai_trace.py
@@ -153,6 +153,28 @@ class KaiTrace:
             f.write(json.dumps(response_metadata, indent=4, default=str))
 
     @enabled_check
+    def estimated_tokens(
+        self,
+        current_batch_count: int,
+        retry_count: int,
+        estimated_tokens: int,
+        token_estimation_encoding_base: str,
+    ):
+        estimated_tokens_file_path = os.path.join(
+            self.trace_dir,
+            f"{current_batch_count}",
+            f"{retry_count}",
+            "estimated_tokens.json",
+        )
+        os.makedirs(os.path.dirname(estimated_tokens_file_path), exist_ok=True)
+        prompt_token_estimate_details = {
+            "encoding_base": token_estimation_encoding_base,
+            "estimated_prompt_tokens": estimated_tokens,
+        }
+        with open(estimated_tokens_file_path, "w") as f:
+            f.write(json.dumps(prompt_token_estimate_details, indent=4))
+
+    @enabled_check
     def exception(
         self,
         current_batch_count: int,

--- a/kai/models/kai_config.py
+++ b/kai/models/kai_config.py
@@ -222,6 +222,9 @@ class KaiConfig(BaseSettings):
     demo_mode: bool = False
     trace_enabled: bool = False
 
+    # Tiktoken configurations
+    token_estimation_encoding_base: str = "gpt-4o"
+
     # Gunicorn settings
     gunicorn_workers: int = 8
     gunicorn_timeout: int = 3600


### PR DESCRIPTION
After merging this PR, token estimates based on the input prompt will be available. Depending on the model being used, the [encoding base ](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py)for Tiktoken can be adjusted to improve the accuracy of the input prompt estimates. The encoding configuration can be updated by modifying the token encoding base setting in the [`config.toml`](https://github.com/devjpt23/kai/blob/prompt-token-estimation/kai/config.toml) file.

```bash
# Default configuration file for Kai. For a better understanding of the
# configuration options, please refer to `build/example_config.toml`

log_level = "info"
file_log_level = "debug"
log_dir = "$pwd/logs"
demo_mode = false
trace_enabled = true
token_estimation_encoding_base = "gpt-4o"  <===== Encoding base
...
```
Futhermore, the estimates of the prompt tokens are saved in a file `estimated_tokens.json`


```bash
TRACE DIRECTORY
── trace
      └── gpt-3.5-turbo << MODEL ID>>
          └── coolstore << APP Name >>
              ├── pom.xml << Source File Path >>
              │   └── single_group << Incident Batch Mode >>
              │       └── 1719673609.8266618 << Start of Request Time Stamp >>
              │           ├── 1 << Incident Batch Number >>
              │           │   ├── 0 << Retry Attempt  >>
              │           │   │   ├── llm_result << Contains the response from the LLM prior to us parsing >>
              │           │   │   ├── token_usage.json << New metadata file added here >>
              │           │   │   ├── estimated_tokens.json << Newly added metadata file with estimated tokens >>
              │           │   │   ├── prompt << The formatted prompt prior to sending to LLM >>
              │           │   │   └── prompt_vars.json << The prompt variables which are injected into the prompt template >>
              │           │   ├── params.json << Request parameters >>
              │           │   └── timing << Duration of a Successful Request >>
              └── src
                  └── main
                      ├── java
                      │   └── com
                      │       └── redhat
                      │           └── coolstore
                      │               ├── model
                      │               │   ├── InventoryEntity.java
                      │               │   │   └── single_group
                      │               │   │       └── 1719673609.827135
                      │               │   │           ├── 1
                      │               │   │           │   ├── 0
                      │               │   │           │   │   ├── llm_result
                      │               │   │           │   │   ├── token_usage.json << New metadata file added here >>
                      │               │   │           │   │   ├── estimated_tokens.json << Newly added metadata file with estimated tokens >>
                      │               │   │           │   ├── prompt
                      │               │   │           │   └── prompt_vars.json
                      │               │   │           ├── params.json
                      │               │   │           └── timing
                      │               │   ├── Order.java
                      │               │   │   └── single_group
                      │               │   │       └── 1719673609.826999
                      │               │   │           ├── 1
                      │               │   │           │   ├── 0
                      │               │   │           │   │   ├── llm_result
                      │               │   │           │   │   ├── token_usage.json << New metadata file added here >>
                      │               │   │           │   │   ├── estimated_tokens.json << Newly added metadata file with estimated tokens >>
                      │               │   │           ├── prompt
                      │               │   │           └── prompt_vars.json
                      │               │   ├── params.json
                      │               │   └── timing
```