### PR TITLE
Add a hierarchical task structure

### DIFF
--- a/playpen/repo_level_awareness/api.py
+++ b/playpen/repo_level_awareness/api.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
 
@@ -14,9 +14,44 @@ class RpcClientConfig:
     included_paths: Optional[List[str]]
 
 
-@dataclass
+@dataclass(eq=False, kw_only=True)
 class Task:
-    pass
+    priority: int = 10
+    depth: int = 0
+    parent: Optional["Task"] = None
+    children: List["Task"] = field(default_factory=list, compare=False)
+
+    def __eq__(self, other):
+        return isinstance(other, Task) and self.__dict__ == other.__dict__
+
+    def __lt__(self, other):
+        # Lower priority number means higher priority
+        # For same priority, higher depth means process children first (DFS)
+        return (self.priority, -self.depth) < (other.priority, -other.depth)
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.__dict__.items())))
+
+
+@dataclass(eq=False, kw_only=True)
+class ValidationError(Task):
+    file: str
+    line: int
+    column: int
+    message: str
+    priority: int = 5
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and self.file == other.file
+            and self.line == other.line
+            and self.column == other.column
+            and self.message == other.message
+        )
+
+    def __hash__(self):
+        return hash((self.file, self.line, self.column, self.message))
 
 
 # FIXME: Might not need
@@ -24,14 +59,6 @@ class Task:
 class TaskResult:
     encountered_errors: list[str]
     modified_files: list[Path]
-
-
-@dataclass
-class ValidationError(Task):
-    file: str
-    line: int
-    column: int
-    message: str
 
 
 @dataclass

--- a/playpen/repo_level_awareness/api.py
+++ b/playpen/repo_level_awareness/api.py
@@ -20,6 +20,8 @@ class Task:
     depth: int = 0
     parent: Optional["Task"] = None
     children: List["Task"] = field(default_factory=list, compare=False)
+    retry_count: int = 0
+    max_retries: int = 3
 
     def __eq__(self, other):
         return isinstance(other, Task) and self.__dict__ == other.__dict__

--- a/playpen/repo_level_awareness/codeplan.py
+++ b/playpen/repo_level_awareness/codeplan.py
@@ -253,7 +253,7 @@ class TaskManager:
                 old_task.depth = task.depth
                 old_task.retry_count = task.retry_count
                 logger.debug("Task %s still unprocessed after execution.", task)
-                self.handle_ignored_task(old_tasks[0])
+                self.handle_ignored_task(old_task)
             else:
                 self.processed_tasks.add(task)
                 logger.debug("Task %s processed successfully.", task)

--- a/playpen/repo_level_awareness/task_runner/analyzer_lsp/api.py
+++ b/playpen/repo_level_awareness/task_runner/analyzer_lsp/api.py
@@ -9,5 +9,7 @@ class AnalyzerRuleViolation(ValidationError):
     incident: Incident
     violation: Violation
     ruleset: RuleSet
+    # TODO Highest priority?
+    priority: int = 1
 
     # TODO: Define a new hash function?

--- a/playpen/repo_level_awareness/task_runner/analyzer_lsp/api.py
+++ b/playpen/repo_level_awareness/task_runner/analyzer_lsp/api.py
@@ -4,8 +4,10 @@ from kai.models.report_types import Incident, RuleSet, Violation
 from playpen.repo_level_awareness.api import ValidationError
 
 
-@dataclass
+@dataclass(eq=False, kw_only=True)
 class AnalyzerRuleViolation(ValidationError):
     incident: Incident
     violation: Violation
     ruleset: RuleSet
+
+    # TODO: Define a new hash function?

--- a/playpen/repo_level_awareness/task_runner/compiler/maven_validator.py
+++ b/playpen/repo_level_awareness/task_runner/compiler/maven_validator.py
@@ -20,7 +20,7 @@ class MavenCompileStep(ValidationStep):
         return ValidationResult(passed=not errors, errors=errors)
 
 
-@dataclass
+@dataclass(eq=False)
 class MavenCompilerError(ValidationError):
     details: List[str] = field(default_factory=list)
     parse_lines: Optional[str] = None
@@ -44,39 +44,39 @@ class MavenCompilerError(ValidationError):
 
 
 # Subclasses for specific error categories
-@dataclass
+@dataclass(eq=False)
 class SymbolNotFoundError(MavenCompilerError):
     missing_symbol: Optional[str] = None
     symbol_location: Optional[str] = None
 
 
-@dataclass
+@dataclass(eq=False)
 class PackageDoesNotExistError(MavenCompilerError):
     missing_package: Optional[str] = None
 
 
-@dataclass
+@dataclass(eq=False)
 class SyntaxError(MavenCompilerError):
     pass
 
 
-@dataclass
+@dataclass(eq=False)
 class TypeMismatchError(MavenCompilerError):
     expected_type: Optional[str] = None
     found_type: Optional[str] = None
 
 
-@dataclass
+@dataclass(eq=False)
 class AnnotationError(MavenCompilerError):
     pass
 
 
-@dataclass
+@dataclass(eq=False)
 class AccessControlError(MavenCompilerError):
     inaccessible_class: Optional[str] = None
 
 
-@dataclass
+@dataclass(eq=False)
 class OtherError(MavenCompilerError):
     pass
 

--- a/playpen/repo_level_awareness/task_runner/compiler/maven_validator.py
+++ b/playpen/repo_level_awareness/task_runner/compiler/maven_validator.py
@@ -52,12 +52,13 @@ class SymbolNotFoundError(MavenCompilerError):
 
 @dataclass(eq=False)
 class PackageDoesNotExistError(MavenCompilerError):
+    priority: int = 3
     missing_package: Optional[str] = None
 
 
 @dataclass(eq=False)
 class SyntaxError(MavenCompilerError):
-    pass
+    priority: int = 2
 
 
 @dataclass(eq=False)
@@ -78,7 +79,7 @@ class AccessControlError(MavenCompilerError):
 
 @dataclass(eq=False)
 class OtherError(MavenCompilerError):
-    pass
+    priority: int = 6
 
 
 def run_maven(source_directory=".") -> str:

--- a/playpen/repo_level_awareness/tests/test_priority_queue.py
+++ b/playpen/repo_level_awareness/tests/test_priority_queue.py
@@ -1,0 +1,284 @@
+import unittest
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+# Import classes from your codebase
+from playpen.repo_level_awareness.api import (
+    RpcClientConfig,
+    Task,
+    TaskResult,
+    ValidationError,
+    ValidationResult,
+    ValidationStep,
+)
+from playpen.repo_level_awareness.codeplan import TaskManager
+
+
+class MockValidationStep(ValidationStep):
+    def __init__(
+        self, config: RpcClientConfig, error_sequences: List[List[ValidationError]]
+    ):
+        super().__init__(config)
+        self.error_sequences = error_sequences
+        self.run_count = 0
+
+    def run(self) -> ValidationResult:
+        if self.run_count < len(self.error_sequences):
+            errors = self.error_sequences[self.run_count]
+        else:
+            errors = []
+        self.run_count += 1
+        passed = len(errors) == 0
+        return ValidationResult(passed=passed, errors=errors)
+
+
+class MockTaskRunner:
+    def can_handle_task(self, task: Task) -> bool:
+        return True  # For testing, assume it can handle any task
+
+    def execute_task(self, rcm, task: Task) -> TaskResult:
+        # Simulate task execution by returning a TaskResult
+        return TaskResult(encountered_errors=[], modified_files=[])
+
+
+class TestTaskManager(unittest.TestCase):
+    def test_simple_task_execution_order(self):
+        # Setup
+        validator = MockValidationStep(
+            config=None,
+            error_sequences=[
+                [
+                    ValidationError(file="test.py", line=1, column=1, message="Error1")
+                ],  # First run
+                [],  # Second run, no errors
+            ],
+        )
+        task_manager = TaskManager(
+            config=None,
+            rcm=None,
+            updated_file_content=None,
+            validators=[validator],
+            agents=[MockTaskRunner()],
+        )
+
+        # Collect executed tasks
+        executed_tasks = []
+
+        # Execute tasks
+        for task in task_manager.get_next_task():
+            executed_tasks.append(task)
+            # Simulate task execution
+            task_manager.processed_tasks.add(task)
+            task_manager.handle_new_tasks_after_processing(task)
+
+        # Assertions
+        self.assertEqual(len(executed_tasks), 1)
+        self.assertEqual(executed_tasks[0].message, "Error1")
+
+    def test_task_with_children_dfs_order(self):
+        # Setup
+        validator = MockValidationStep(
+            config=None,
+            error_sequences=[
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="ParentError"
+                    )
+                ],  # First run
+                [
+                    ValidationError(
+                        file="test.py", line=2, column=1, message="ChildError1"
+                    ),
+                    ValidationError(
+                        file="test.py", line=3, column=1, message="ChildError2"
+                    ),
+                ],  # Second run
+                [],  # Third run, no errors
+            ],
+        )
+        task_manager = TaskManager(
+            config=None,
+            rcm=None,
+            updated_file_content=None,
+            validators=[validator],
+            agents=[MockTaskRunner()],
+        )
+
+        executed_tasks = []
+
+        for task in task_manager.get_next_task():
+            executed_tasks.append(task)
+            # Simulate task execution
+            task_manager.processed_tasks.add(task)
+            task_manager.handle_new_tasks_after_processing(task)
+
+        self.assertEqual(len(executed_tasks), 3)
+        self.assertEqual(
+            [t.message for t in executed_tasks],
+            ["ParentError", "ChildError1", "ChildError2"],
+        )
+        self.assertTrue(executed_tasks[1].depth > executed_tasks[0].depth)
+        self.assertTrue(executed_tasks[2].depth > executed_tasks[0].depth)
+
+    def test_task_retry_logic(self):
+        # Setup
+        validator = MockValidationStep(
+            config=None,
+            error_sequences=[
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="PersistentError"
+                    )
+                ],  # First run
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="PersistentError"
+                    )
+                ],  # Second run
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="PersistentError"
+                    )
+                ],  # Third run
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="PersistentError"
+                    )
+                ],  # Fourth run
+                [],  # Fifth run, error resolved
+            ],
+        )
+        task_manager = TaskManager(
+            config=None,
+            rcm=None,
+            updated_file_content=None,
+            validators=[validator],
+            agents=[MockTaskRunner()],
+        )
+
+        executed_tasks = []
+        retries = 0
+
+        for task in task_manager.get_next_task():
+            executed_tasks.append(task)
+            if task.retry_count > 0:
+                retries += 1
+            # Simulate task execution
+            task_manager.processed_tasks.add(task)
+            task_manager.handle_new_tasks_after_processing(task)
+
+        self.assertEqual(len(executed_tasks), 3)  # max_retries is 3
+        self.assertEqual(executed_tasks[0].message, "PersistentError")
+        self.assertEqual(executed_tasks[0].retry_count, 0)
+        self.assertEqual(executed_tasks[1].retry_count, 1)
+        self.assertEqual(executed_tasks[2].retry_count, 2)
+        self.assertEqual(retries, 2)  # Retries occurred twice
+
+    def test_handling_ignored_tasks(self):
+        # Setup
+        validator = MockValidationStep(
+            config=None,
+            error_sequences=[
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="UnresolvableError"
+                    )
+                ],  # First run
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="UnresolvableError"
+                    )
+                ],  # Second run
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="UnresolvableError"
+                    )
+                ],  # Third run
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="UnresolvableError"
+                    )
+                ],  # Fourth run
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="UnresolvableError"
+                    )
+                ],  # Fifth run
+            ],
+        )
+        task_manager = TaskManager(
+            config=None,
+            rcm=None,
+            updated_file_content=None,
+            validators=[validator],
+            agents=[MockTaskRunner()],
+        )
+
+        for task in task_manager.get_next_task():
+            # Simulate task execution
+            task_manager.processed_tasks.add(task)
+            task_manager.handle_new_tasks_after_processing(task)
+
+        self.assertEqual(len(task_manager.ignored_tasks), 1)
+        ignored_task = task_manager.ignored_tasks[0]
+        self.assertEqual(ignored_task.message, "UnresolvableError")
+        self.assertEqual(ignored_task.retry_count, ignored_task.max_retries)
+
+    def test_complex_task_tree(self):
+        # Setup
+        validator = MockValidationStep(
+            config=None,
+            error_sequences=[
+                [
+                    ValidationError(
+                        file="test.py", line=1, column=1, message="ParentError"
+                    )
+                ],  # First run
+                [
+                    ValidationError(
+                        file="test.py", line=2, column=1, message="ChildError1"
+                    ),
+                    ValidationError(
+                        file="test.py", line=3, column=1, message="ChildError2"
+                    ),
+                ],  # Second run
+                [
+                    ValidationError(
+                        file="test.py", line=4, column=1, message="GrandchildError"
+                    )
+                ],  # Third run
+                [],  # Fourth run, no errors
+            ],
+        )
+        task_manager = TaskManager(
+            config=None,
+            rcm=None,
+            updated_file_content=None,
+            validators=[validator],
+            agents=[MockTaskRunner()],
+        )
+
+        executed_tasks = []
+
+        for task in task_manager.get_next_task():
+            executed_tasks.append((task.depth, task.message))
+            # Simulate task execution
+            task_manager.processed_tasks.add(task)
+            task_manager.handle_new_tasks_after_processing(task)
+
+        executed_tasks_sorted = sorted(
+            executed_tasks, key=lambda x: (x[0], executed_tasks.index(x))
+        )
+
+        expected_order = [
+            (0, "ParentError"),
+            (1, "ChildError1"),
+            (1, "ChildError2"),
+            (2, "GrandchildError"),
+        ]
+        self.assertEqual(executed_tasks_sorted, expected_order)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rather than a simple list of tasks, maintain a priority queue of Task stacks, where new issues spawned from work on a task are added as children of the main task. This allows us to focus on the most relevant issues first, and gives us knobs to play with by being able to tweak the priority of individual tasks/task classes

closes #409