### PR TITLE
:bug: Prevent circular parent-child task relationships

### DIFF
--- a/kai/reactive_codeplanner/task_manager/api.py
+++ b/kai/reactive_codeplanner/task_manager/api.py
@@ -29,6 +29,11 @@ class Task:
 
     _creation_counter = 0
 
+    def oldest_ancestor(self) -> "Task":
+        if self.parent:
+            return self.parent.oldest_ancestor()
+        return self
+
     def __post_init__(self) -> None:
         self.creation_order = Task._creation_counter
         Task._creation_counter += 1
@@ -109,6 +114,11 @@ class ValidationError(Task):
                 and self.message == error2.message
             )
         return False
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}<loc={self.file}:{self.line}:{self.column}, message={self.message}>"
+
+    __repr__ = __str__
 
 
 # FIXME: Might not need

--- a/kai/reactive_codeplanner/task_manager/priority_queue.py
+++ b/kai/reactive_codeplanner/task_manager/priority_queue.py
@@ -22,11 +22,12 @@ class PriorityTaskQueue:
                 # Existing task takes precedence; do not add or modify
                 return
 
-        priority = task.priority
+        priority = task.oldest_ancestor().priority
         if priority not in self.task_stacks:
             self.task_stacks[priority] = []
             logger.debug("Created new task stack for priority %s.", priority)
         self.task_stacks[priority].append(task)
+        self.task_stacks[priority].sort()
         logger.debug("Task %s added to priority %s stack.", task, priority)
 
     def pop(self) -> Task:

--- a/kai/reactive_codeplanner/task_runner/analyzer_lsp/api.py
+++ b/kai/reactive_codeplanner/task_runner/analyzer_lsp/api.py
@@ -18,6 +18,11 @@ class AnalyzerRuleViolation(ValidationError):
     # TODO Highest priority?
     priority: int = 2
 
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}<loc={self.file}:{self.line}:{self.column}, message={self.violation.description}>"
+
+    __repr__ = __str__
+
     # TODO: Define a new hash function?
 
 

--- a/kai/reactive_codeplanner/task_runner/analyzer_lsp/validator.py
+++ b/kai/reactive_codeplanner/task_runner/analyzer_lsp/validator.py
@@ -156,7 +156,7 @@ class AnalyzerLSPStep(ValidationStep):
                         class_to_use = AnalyzerDependencyRuleViolation
                     validation_errors.append(
                         class_to_use(
-                            file=urlparse(i.uri).path,
+                            file=urlparse(i.uri).path.lstrip("/"),
                             line=i.line_number,
                             column=-1,
                             message=i.message,


### PR DESCRIPTION
Also allows children to maintain their original priority level (for sorting) while remaining in the queue of their oldest ancestor