### PR TITLE
:bug: Priority Queue now always returns highest depth tasks for a given priority level first

### DIFF
--- a/kai/reactive_codeplanner/task_manager/api.py
+++ b/kai/reactive_codeplanner/task_manager/api.py
@@ -48,9 +48,9 @@ class Task:
         # Lower priority number means higher priority
         # For same priority, higher depth means process children first (DFS)
         # For same priority and depth, rely on creation order just to make it deterministic
-        return (self.priority, -self.depth, self.creation_order) < (
-            other.priority,
+        return (-self.depth, self.priority, self.creation_order) < (
             -other.depth,
+            other.priority,
             other.creation_order,
         )
 

--- a/kai/reactive_codeplanner/task_manager/priority_queue.py
+++ b/kai/reactive_codeplanner/task_manager/priority_queue.py
@@ -27,7 +27,7 @@ class PriorityTaskQueue:
             self.task_stacks[priority] = []
             logger.debug("Created new task stack for priority %s.", priority)
         self.task_stacks[priority].append(task)
-        self.task_stacks[priority].sort()
+        self.task_stacks[priority].sort(reverse=True)
         logger.debug("Task %s added to priority %s stack.", task, priority)
 
     def pop(self) -> Task:
@@ -64,3 +64,57 @@ class PriorityTaskQueue:
 
     def all_tasks(self) -> set[Task]:
         return set().union(*self.task_stacks.values())
+
+    def __str__(self) -> str:
+        queue_tasks_set = self.all_tasks()
+        top_level_tasks = set(task.oldest_ancestor() for task in queue_tasks_set)
+        visited: set[Task] = set()
+
+        lines = []
+        for task in top_level_tasks:
+            lines.extend(
+                self._stringify_tasks(
+                    task,
+                    indent=0,
+                    visited=visited,
+                    queue_tasks_set=queue_tasks_set,
+                )
+            )
+        return "\n".join(lines)
+
+    def _stringify_tasks(
+        self,
+        task: Task,
+        indent: int,
+        visited: set[Task],
+        queue_tasks_set: set[Task],
+    ) -> list[str]:
+        lines = []
+        if task in visited:
+            logger.debug(
+                "%s%s(...)  # Already printed",
+                "  " * indent,
+                task.__class__.__name__,
+            )
+            return []
+        visited.add(task)
+
+        status = "" if task in queue_tasks_set else "  # solved"
+        prefix = ""
+        if task.depth > 0:
+            prefix = "|" + "-" * indent
+
+        lines.append(
+            f"{prefix}{task}(priority={task.priority}, depth={task.depth}){status}"
+        )
+
+        for child in task.children:
+            lines.extend(
+                self._stringify_tasks(
+                    child,
+                    indent=indent + 1,
+                    visited=visited,
+                    queue_tasks_set=queue_tasks_set,
+                )
+            )
+        return lines


### PR DESCRIPTION
- Changes `__lt__` behavior of tasks to do depth then priority
- Fixes the priority queue sort when a task is appended so that it can pop the next task properly
- Adds a `__str__` function to the priority queue for easier introspection during debugging
- Adds timing information and queue state logging to the `reactive_codeplanner/main.py`, to aid debugging