### PR TITLE
:sparkles: Maven Validator now properly detects and reports build errors

### DIFF
--- a/kai/reactive_codeplanner/agent/maven_compiler_fix/agent.py
+++ b/kai/reactive_codeplanner/agent/maven_compiler_fix/agent.py
@@ -104,7 +104,7 @@ class MavenCompilerAgent(Agent):
             if in_java_file:
                 if "```java" in line or "```" in line:
                     continue
-                java_file = "\n".join([java_file, line])
+                java_file = "\n".join([java_file, line]).strip()
             if in_reasoning:
                 reasoning = "\n".join([reasoning, line])
             if in_additional_details:

--- a/kai/reactive_codeplanner/task_runner/compiler/compiler_task_runner.py
+++ b/kai/reactive_codeplanner/task_runner/compiler/compiler_task_runner.py
@@ -14,6 +14,8 @@ from kai.reactive_codeplanner.task_runner.api import TaskRunner
 from kai.reactive_codeplanner.task_runner.compiler.maven_validator import (
     AccessControlError,
     AnnotationError,
+    BuildError,
+    DependencyResolutionError,
     MavenCompilerError,
     OtherError,
     SyntaxError,
@@ -43,11 +45,13 @@ class MavenCompilerTaskRunner(TaskRunner):
     """
 
     handled_type = (
+        BuildError,
         SyntaxError,
         TypeMismatchError,
         AnnotationError,
         AccessControlError,
         OtherError,
+        DependencyResolutionError,
     )
 
     def __init__(self, agent: MavenCompilerAgent) -> None:

--- a/kai/reactive_codeplanner/task_runner/compiler/maven_validator.py
+++ b/kai/reactive_codeplanner/task_runner/compiler/maven_validator.py
@@ -24,8 +24,10 @@ class MavenCompileStep(ValidationStep):
 
     @tracer.start_as_current_span("maven_run_validator")
     def run(self) -> ValidationResult:
-        maven_output = run_maven(self.config.repo_directory)
-        errors: Sequence[ValidationError] = parse_maven_output(maven_output)
+        rc, maven_output, pom_file_path = run_maven(self.config.repo_directory)
+        errors: Sequence[ValidationError] = parse_maven_output(
+            maven_output, rc, str(pom_file_path)
+        )
         return ValidationResult(passed=not errors, errors=errors)
 
 
@@ -43,8 +45,8 @@ class MavenCompilerError(ValidationError):
         Factory method to create an instance from a regex match.
         """
         file_path = match.group(1).strip()
-        line_number = int(match.group(2))
-        column_number = int(match.group(3))
+        line_number = int(match.group(2)) if match.group(2) else -1
+        column_number = int(match.group(3)) if match.group(3) else -1
         message = match.group(4).strip()
         return cls(
             file=file_path,
@@ -56,6 +58,18 @@ class MavenCompilerError(ValidationError):
 
 
 # Subclasses for specific error categories
+@dataclass(eq=False)
+class BuildError(MavenCompilerError):
+    priority: int = 1
+
+
+@dataclass(eq=False)
+class DependencyResolutionError(MavenCompilerError):
+    priority: int = 1
+    project: str = ""
+    goal: str = ""
+
+
 @dataclass(eq=False)
 class SymbolNotFoundError(MavenCompilerError):
     missing_symbol: Optional[str] = None
@@ -95,9 +109,10 @@ class OtherError(MavenCompilerError):
     priority: int = 6
 
 
-def run_maven(source_directory: Path = Path(".")) -> str:
+def run_maven(source_directory: Path = Path(".")) -> tuple[int, str, Optional[Path]]:
     """
     Runs 'mvn compile' and returns the combined stdout and stderr output.
+    Also returns the path to the pom.xml file.
     """
     cmd = ["mvn", "compile"]
     #  trunk-ignore-begin(bandit/B603)
@@ -110,11 +125,12 @@ def run_maven(source_directory: Path = Path(".")) -> str:
             check=False,
             cwd=source_directory,
         )
-        return process.stdout
+        pom_file_path = source_directory / "pom.xml"
+        return (process.returncode, process.stdout, pom_file_path)
     #  trunk-ignore-end(bandit/B603)
     except FileNotFoundError:
         logger.info("Maven is not installed or not found in the system PATH.")
-        return ""
+        return -1, "", None
 
 
 def classify_error(message: str) -> Type[MavenCompilerError]:
@@ -143,87 +159,292 @@ def classify_error(message: str) -> Type[MavenCompilerError]:
         return OtherError
 
 
-def parse_maven_output(output: str) -> Sequence[MavenCompilerError]:
+def parse_maven_output(
+    output: str, rc: int, pom_file_path: Optional[str] = None
+) -> Sequence[MavenCompilerError]:
     """
     Parses the Maven output and returns a list of MavenCompilerError instances.
     """
-    errors: list[MavenCompilerError] = []
     lines = output.splitlines()
-    in_compilation_error_section = False
-    error_pattern = re.compile(r"\[ERROR\] (.+?):\[(\d+),(\d+)\] (.+)")
-    current_error: MavenCompilerError
-
-    acc = []
-    for i, line in enumerate(lines):
-        if "[ERROR] COMPILATION ERROR :" in line:
-            in_compilation_error_section = True
+    errors: list[MavenCompilerError] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "[ERROR] Some problems were encountered while processing the POMs:" in line:
+            i, build_errors = parse_build_errors(lines, i + 1, pom_file_path)
+            errors.extend(build_errors)
             continue
-        if in_compilation_error_section:
-            if line.startswith("[INFO] BUILD FAILURE"):
-                in_compilation_error_section = False
+        elif "[ERROR] COMPILATION ERROR :" in line:
+            i, compilation_errors = parse_compilation_errors(lines, i)
+            errors.extend(compilation_errors)
+            continue
+        elif "[ERROR] Failed to execute goal" in line:
+            error, new_index = parse_dependency_resolution_error(
+                lines, i, pom_file_path
+            )
+            if error:
+                errors.append(error)
+                i = new_index
                 continue
-            if (
-                line.startswith("[INFO]")
-                or line.startswith("[WARNING]")
-                or line.strip() == ""
-            ):
-                # TODO what to do with these?
-                continue
-            # Match error lines with file path, line, column, and message
-            match = error_pattern.match(line)
-            if match:
-                acc.append(line)
-                error_class = classify_error(match.group(4))
-                current_error = error_class.from_match(match, [])
-
-                # Look ahead for details
-                details = []
-                j = i + 1
-                while j < len(lines) and lines[j].startswith("  "):
-                    acc.append(lines[j])
-                    detail_line = lines[j].replace("[ERROR] ", "", -1).strip()
-                    details.append(detail_line)
-                    j += 1
-
-                current_error.details.extend(details)
-                # Extract additional information based on error type
-                if isinstance(current_error, SymbolNotFoundError):
-                    for detail in current_error.details:
-                        if "symbol:" in detail:
-                            current_error.missing_symbol = detail.split("symbol:")[
-                                -1
-                            ].strip()
-                        if "location:" in detail:
-                            current_error.symbol_location = detail.split("location:")[
-                                -1
-                            ].strip()
-                elif isinstance(current_error, PackageDoesNotExistError):
-                    current_error.missing_package = (
-                        current_error.message.split("package")[-1]
-                        .split("does not exist")[0]
-                        .strip()
-                    )
-                elif isinstance(current_error, TypeMismatchError):
-                    for detail in current_error.details:
-                        if "required:" in detail:
-                            current_error.expected_type = detail.split("required:")[
-                                -1
-                            ].strip()
-                        if "found:" in detail:
-                            current_error.found_type = detail.split("found:")[
-                                -1
-                            ].strip()
-                elif isinstance(current_error, AccessControlError):
-                    current_error.inaccessible_class = current_error.message.split(
-                        "cannot access"
-                    )[-1].strip()
-
-                current_error.parse_lines = "\n".join(acc)
-                errors.append(current_error)
-                acc = []
             else:
-                continue  # Line does not match error pattern
-    return errors
+                i += 1
+        else:
+            i += 1
+    if rc != 0 and not errors:
+        errors.append(catchall(output))
+    return deduplicate_errors(errors)
+
+
+def parse_build_errors(
+    lines: list[str], start_index: int, pom_file_path: Optional[str]
+) -> tuple[int, list[MavenCompilerError]]:
+    """
+    Parses the build error section and returns a list of BuildError instances.
+    """
+    errors = []
+    i = start_index
+    file_path = pom_file_path or "pom.xml"
+    matched_project = False
+
+    while i < len(lines):
+        line = lines[i]
+        if is_section_end(line):
+            break
+
+        # Match project line to get file path
+        project_match = re.match(
+            r"\[ERROR\]\s+The project\s*(?:.+?)?\s*\((.+pom\.xml)\) has \d+ error", line
+        )
+        if project_match:
+            file_path = project_match.group(1).strip()
+            matched_project = True
+            i += 1
+            continue
+
+        if matched_project:
+            # Only parse build errors after matching a project line
+            build_error = match_build_error(line, file_path)
+            if build_error:
+                error = build_error
+                # Collect details if any
+                details = []
+                i += 1
+                while i < len(lines) and lines[i].startswith("[ERROR]     "):
+                    detail_line = lines[i].replace("[ERROR]     ", "", 1).strip()
+                    details.append(detail_line)
+                    i += 1
+                error.details.extend(details)
+                errors.append(error)
+                continue
+        else:
+            # Skip lines until we match a project line
+            i += 1
+
+    return i, errors
+
+
+def parse_dependency_resolution_error(
+    lines: list[str], index: int, pom_file_path: Optional[str]
+) -> tuple[Optional[MavenCompilerError], int]:
+    """
+    Parses a dependency resolution error starting from the given index.
+    """
+    line = lines[index]
+    pattern = re.compile(
+        r"\[ERROR\] Failed to execute goal(?: (.+?))? on project ([^:]+): (.+)"
+    )
+    match = pattern.match(line.strip())
+    if match:
+        goal = match.group(1).strip() if match.group(1) else ""
+        project = match.group(2).strip()
+        message = match.group(3).strip()
+        if "could not resolve dependencies" in message.lower():
+            # Collect details from subsequent [ERROR] lines
+            details = []
+            i = index + 1
+            while i < len(lines) and lines[i].strip().startswith("[ERROR]"):
+                detail_line = lines[i].strip()[8:].strip()
+                details.append(detail_line)
+                i += 1
+            error = DependencyResolutionError(
+                file=pom_file_path or "pom.xml",
+                line=-1,
+                column=-1,
+                message=message,
+                details=details,
+                parse_lines="\n".join(lines[index:i]),
+                project=project,
+                goal=goal,
+            )
+            return error, i
+    return None, index + 1
+
+
+def parse_compilation_errors(
+    lines: list[str], start_index: int
+) -> tuple[int, list[MavenCompilerError]]:
+    """
+    Parses the compilation error section and returns a list of MavenCompilerError instances.
+    """
+    errors = []
+    i = start_index
+    while i < len(lines):
+        line = lines[i]
+        if is_section_end(line):
+            break
+
+        # Ignore non-error lines
+        if (
+            line.startswith("[INFO]")
+            or line.startswith("[WARNING]")
+            or line.strip() == ""
+        ):
+            i += 1
+            continue
+
+        match = re.match(r"\[ERROR\] (.+?):(?:\[(\d+),(\d+)\])? (.+)", line)
+        if match:
+            error, i = parse_error_line(lines, i, match)
+            errors.append(error)
+        else:
+            i += 1
+    return i, errors
+
+
+def is_section_end(line: str) -> bool:
+    """
+    Determines if the current line indicates the end of an error section.
+    """
+    return line.startswith("[INFO] BUILD FAILURE") or line.startswith(
+        "[ERROR] BUILD FAILURE"
+    )
+
+
+def match_build_error(line: str, file_path: str) -> Optional[MavenCompilerError]:
+    """
+    Matches a build error line and returns a BuildError instance.
+    """
+    build_error_pattern = re.compile(
+        r"\s*\[(ERROR|FATAL)\]\s*(.+?) @ line (\d+), column (\d+)"
+    )
+    match = build_error_pattern.match(line)
+    if match:
+        message = match.group(2).strip()
+        line_number = int(match.group(3))
+        column_number = int(match.group(4))
+        # Try to extract file path from message
+        file_path_match = re.search(r"Non-parseable POM (.+?):", message)
+        if file_path_match:
+            file_path = file_path_match.group(1).strip()
+        error = BuildError(
+            file=file_path,
+            line=line_number,
+            column=column_number,
+            message=message,
+            details=[],
+        )
+        return error
+    return None
+
+
+def parse_error_line(
+    lines: list[str], index: int, match: re.Match[str]
+) -> tuple[MavenCompilerError, int]:
+    """
+    Parses an error line and returns a MavenCompilerError instance and the next index.
+    """
+    acc = [lines[index]]
+    file_path = match.group(1).strip()
+    line_number = int(match.group(2)) if match.group(2) else -1
+    column_number = int(match.group(3)) if match.group(3) else -1
+    message = match.group(4).strip()
+
+    error_class = classify_error(message)
+    error = error_class(
+        file=file_path,
+        line=line_number,
+        column=column_number,
+        message=message,
+        details=[],
+    )
+
+    # Look ahead for details
+    details, next_index = extract_error_details(lines, index + 1)
+    error.details.extend(details)
+
+    # Extract additional information based on error type
+    extract_additional_info(error)
+
+    error.parse_lines = "\n".join(acc + details)
+    return error, next_index
+
+
+def extract_error_details(lines: list[str], start_index: int) -> tuple[list[str], int]:
+    """
+    Extracts detail lines following an error line.
+    """
+    details = []
+    i = start_index
+    while i < len(lines) and lines[i].startswith("  "):
+        detail_line = lines[i].strip()
+        details.append(detail_line)
+        i += 1
+    return details, i
+
+
+def extract_additional_info(error: MavenCompilerError) -> None:
+    """
+    Extracts additional information based on error type.
+    """
+    if isinstance(error, SymbolNotFoundError):
+        for detail in error.details:
+            if "symbol:" in detail:
+                error.missing_symbol = detail.split("symbol:")[-1].strip()
+            if "location:" in detail:
+                error.symbol_location = detail.split("location:")[-1].strip()
+    elif isinstance(error, PackageDoesNotExistError):
+        error.missing_package = (
+            error.message.split("package")[-1].split("does not exist")[0].strip()
+        )
+    elif isinstance(error, TypeMismatchError):
+        for detail in error.details:
+            if "required:" in detail:
+                error.expected_type = detail.split("required:")[-1].strip()
+            if "found:" in detail:
+                error.found_type = detail.split("found:")[-1].strip()
+    elif isinstance(error, AccessControlError):
+        error.inaccessible_class = error.message.split("cannot access")[-1].strip()
+
+
+def catchall(output: str) -> OtherError:
+    """
+    Failsafe mechanism when rc != 0 and no errors are found.
+    """
+    file_path_pattern = re.compile(r"(/[^:\s]+)")
+    file_path_matches = file_path_pattern.findall(output)
+    file_path = file_path_matches[0] if file_path_matches else "unknown file"
+    return OtherError(
+        file=file_path,
+        line=-1,
+        column=-1,
+        message="Unknown error occurred during Maven build.",
+        details=[output],
+        parse_lines=output,
+    )
+
+
+def deduplicate_errors(errors: list[MavenCompilerError]) -> list[MavenCompilerError]:
+    """
+    Deduplicates errors based on file, line, column, and message.
+    """
+    unique_errors = []
+    seen_errors = set()
+    for error in errors:
+        error_id = (error.file, error.line, error.column, error.message)
+        if error_id not in seen_errors:
+            seen_errors.add(error_id)
+            unique_errors.append(error)
+    return unique_errors
 
 
 if __name__ == "__main__":
@@ -236,10 +457,10 @@ if __name__ == "__main__":
         "source_directory", help="The directory where 'mvn compile' should be run."
     )
     args = parser.parse_args()
-    maven_output = run_maven(Path(args.source_directory))
+    rc, maven_output, pom_file_path = run_maven(Path(args.source_directory))
 
     results: dict[str, list[MavenCompilerError]] = {}
-    for error in parse_maven_output(maven_output):
+    for error in parse_maven_output(maven_output, rc, str(pom_file_path)):
         if not results.get(error.file):
             results[error.file] = [error]
         else:
@@ -249,7 +470,6 @@ if __name__ == "__main__":
         print(errs_line)
         print("-" * len(errs_line))
         for error in errors:
-            # print(f"File: {error.file}")
             print(f"Line: {error.line}, Column: {error.column}")
             print(f"Type: {type(error).__name__}")
             print(f"Message: {error.message}")

--- a/kai/reactive_codeplanner/task_runner/dependency/task_runner.py
+++ b/kai/reactive_codeplanner/task_runner/dependency/task_runner.py
@@ -50,10 +50,7 @@ class DependencyTaskRunner(TaskRunner):
 
     @tracer.start_as_current_span("dependency_task_execute")
     def execute_task(self, rcm: RepoContextManager, task: Task) -> TaskResult:
-        if not isinstance(
-            task,
-            (DependencyTaskResponse, SymbolNotFoundError, PackageDoesNotExistError),
-        ):
+        if not isinstance(task, self.handled_type):
             logger.error("Unexpected task type %r", task)
             return TaskResult(encountered_errors=[], modified_files=[])
 

--- a/tests/test_maven_compiler_agent.py
+++ b/tests/test_maven_compiler_agent.py
@@ -37,7 +37,7 @@ class TestMavenCompilerAgent(unittest.TestCase):
         expected = MavenCompilerAgentResult(
             file_to_modify=Path(""),
             reasoning="\n1. Frobinate the widget\n",
-            updated_file_contents="\nimport str\nimport class",
+            updated_file_contents="import str\nimport class",
             additional_information="\ntesting added info",
             original_file="",
             message="",

--- a/tests/test_maven_validator.py
+++ b/tests/test_maven_validator.py
@@ -1,0 +1,400 @@
+import unittest
+
+from kai.reactive_codeplanner.task_runner.compiler.maven_validator import (
+    AccessControlError,
+    BuildError,
+    DependencyResolutionError,
+    OtherError,
+    PackageDoesNotExistError,
+    SymbolNotFoundError,
+    SyntaxError,
+    TypeMismatchError,
+    parse_maven_output,
+)
+
+
+class TestParseMavenOutput(unittest.TestCase):
+
+    def test_no_errors(self):
+        # Test case where Maven runs successfully without errors
+        maven_output = """
+[INFO] Scanning for projects...
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+"""
+        rc = 0
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 0, "Expected no errors for successful build.")
+
+    def test_symbol_not_found_error(self):
+        # Test case for 'cannot find symbol' error
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/MyClass.java:[10,15] cannot find symbol
+  symbol:   variable x
+  location: class MyClass
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 1, "Expected one error.")
+        error = errors[0]
+        self.assertIsInstance(error, SymbolNotFoundError)
+        self.assertEqual(error.file, "/path/to/MyClass.java")
+        self.assertEqual(error.line, 10)
+        self.assertEqual(error.column, 15)
+        self.assertEqual(error.missing_symbol, "variable x")
+        self.assertEqual(error.symbol_location, "class MyClass")
+
+    def test_package_does_not_exist_error(self):
+        # Test case for 'package does not exist' error
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/AnotherClass.java:[5,8] package com.example.missing does not exist
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 1, "Expected one error.")
+        error = errors[0]
+        self.assertIsInstance(error, PackageDoesNotExistError)
+        self.assertEqual(error.file, "/path/to/AnotherClass.java")
+        self.assertEqual(error.line, 5)
+        self.assertEqual(error.column, 8)
+        self.assertEqual(error.missing_package, "com.example.missing")
+
+    def test_syntax_error(self):
+        # Test case for syntax error
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/InvalidSyntax.java:[20,5] class, interface, or enum expected
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 1, "Expected one error.")
+        error = errors[0]
+        self.assertIsInstance(error, SyntaxError)
+        self.assertEqual(error.file, "/path/to/InvalidSyntax.java")
+        self.assertEqual(error.line, 20)
+        self.assertEqual(error.column, 5)
+
+    def test_type_mismatch_error(self):
+        # Test case for type mismatch error
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/TypeMismatch.java:[15,25] incompatible types: String cannot be converted to int
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 1, "Expected one error.")
+        error = errors[0]
+        self.assertIsInstance(error, TypeMismatchError)
+        self.assertEqual(error.file, "/path/to/TypeMismatch.java")
+        self.assertEqual(error.line, 15)
+        self.assertEqual(error.column, 25)
+        self.assertEqual(
+            error.message, "incompatible types: String cannot be converted to int"
+        )
+
+    def test_access_control_error(self):
+        # Test case for access control error
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/AccessError.java:[30,10] cannot access com.example.PrivateClass
+  class file for com.example.PrivateClass not found
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 1, "Expected one error.")
+        error = errors[0]
+        self.assertIsInstance(error, AccessControlError)
+        self.assertEqual(error.file, "/path/to/AccessError.java")
+        self.assertEqual(error.line, 30)
+        self.assertEqual(error.column, 10)
+        self.assertEqual(error.inaccessible_class, "com.example.PrivateClass")
+
+    def test_build_error(self):
+        # Test case for a build error
+        maven_output = """
+[ERROR] Some problems were encountered while processing the POMs:
+[FATAL] Non-parseable POM /path/to/pom.xml: expected start tag not found @ line 3, column 15
+[ERROR] The build could not read 1 project -> [Help 1]
+[ERROR]   The project  (/path/to/pom.xml) has 1 error
+[ERROR]     Non-parseable POM /path/to/pom.xml: expected start tag not found @ line 3, column 15 -> [Help 2]
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 1, "Expected one build error.")
+        error = errors[0]
+        self.assertIsInstance(error, BuildError)
+        self.assertEqual(error.file, "/path/to/pom.xml")
+        self.assertEqual(error.line, 3)
+        self.assertEqual(error.column, 15)
+        self.assertTrue("Non-parseable POM" in error.message)
+
+    def test_multiple_identical_build_errors(self):
+        # Test case where the same build error appears multiple times
+        maven_output = """
+[ERROR] Some problems were encountered while processing the POMs:
+[FATAL] Non-parseable POM /path/to/pom.xml: invalid content @ line 5, column 20
+[ERROR] The build could not read 1 project -> [Help 1]
+[ERROR]   The project  (/path/to/pom.xml) has 1 error
+[ERROR]     Non-parseable POM /path/to/pom.xml: invalid content @ line 5, column 20 -> [Help 2]
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        # Assuming deduplication is implemented in parse_maven_output
+        self.assertEqual(
+            len(errors), 1, "Expected one unique build error despite duplicates."
+        )
+        error = errors[0]
+        self.assertIsInstance(error, BuildError)
+        self.assertEqual(error.file, "/path/to/pom.xml")
+        self.assertEqual(error.line, 5)
+        self.assertEqual(error.column, 20)
+
+    def test_failsafe_mechanism(self):
+        # Test case where rc != 0 but no errors are parsed, triggering the failsafe
+        maven_output = """
+[INFO] Scanning for projects...
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project my-app: Compilation failure
+[ERROR] 
+[ERROR] -> [Help 1]
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(
+            len(errors), 1, "Expected one error due to failsafe mechanism."
+        )
+        error = errors[0]
+        self.assertIsInstance(error, OtherError)
+        self.assertEqual(error.file, "unknown file")
+        self.assertEqual(error.line, -1)
+        self.assertEqual(error.column, -1)
+        self.assertEqual(error.message, "Unknown error occurred during Maven build.")
+        self.assertIn("BUILD FAILURE", error.details[0])
+
+    def test_unhandled_error(self):
+        # Test case for an error that doesn't match any known patterns
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/UnknownError.java:[50,20] unexpected error: unknown reason
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 1, "Expected one error.")
+        error = errors[0]
+        self.assertIsInstance(error, OtherError)
+        self.assertEqual(error.file, "/path/to/UnknownError.java")
+        self.assertEqual(error.line, 50)
+        self.assertEqual(error.column, 20)
+        self.assertEqual(error.message, "unexpected error: unknown reason")
+
+    def test_multiple_errors(self):
+        # Test case with multiple different errors
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/ClassOne.java:[10,15] cannot find symbol
+  symbol:   method doSomething()
+  location: class ClassOne
+[ERROR] /path/to/ClassTwo.java:[5,8] package com.example.missing does not exist
+[INFO] 2 errors
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 2, "Expected two errors.")
+        # First error
+        error1 = errors[0]
+        self.assertIsInstance(error1, SymbolNotFoundError)
+        self.assertEqual(error1.file, "/path/to/ClassOne.java")
+        self.assertEqual(error1.line, 10)
+        self.assertEqual(error1.column, 15)
+        self.assertEqual(error1.missing_symbol, "method doSomething()")
+        self.assertEqual(error1.symbol_location, "class ClassOne")
+        # Second error
+        error2 = errors[1]
+        self.assertIsInstance(error2, PackageDoesNotExistError)
+        self.assertEqual(error2.file, "/path/to/ClassTwo.java")
+        self.assertEqual(error2.line, 5)
+        self.assertEqual(error2.column, 8)
+        self.assertEqual(error2.missing_package, "com.example.missing")
+
+    def test_duplicate_compilation_errors(self):
+        # Test case with duplicate compilation errors
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/DuplicateError.java:[25,30] cannot find symbol
+  symbol:   class MissingClass
+  location: package com.example
+[ERROR] /path/to/DuplicateError.java:[25,30] cannot find symbol
+  symbol:   class MissingClass
+  location: package com.example
+[INFO] 2 errors
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        # Assuming deduplication is implemented
+        self.assertEqual(
+            len(errors), 1, "Expected one unique error despite duplicates."
+        )
+        error = errors[0]
+        self.assertIsInstance(error, SymbolNotFoundError)
+        self.assertEqual(error.file, "/path/to/DuplicateError.java")
+        self.assertEqual(error.line, 25)
+        self.assertEqual(error.column, 30)
+        self.assertEqual(error.missing_symbol, "class MissingClass")
+        self.assertEqual(error.symbol_location, "package com.example")
+
+    def test_maven_not_installed(self):
+        # Test case where Maven is not installed
+        maven_output = ""
+        rc = -1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(
+            len(errors), 1, "Expected one error due to Maven not being installed."
+        )
+        error = errors[0]
+        self.assertIsInstance(error, OtherError)
+        self.assertEqual(error.file, "unknown file")
+        self.assertEqual(error.message, "Unknown error occurred during Maven build.")
+
+    def test_compile_error_with_details(self):
+        # Test case with compilation error including detailed messages
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/ComplexError.java:[40,22] incompatible types: int cannot be converted to String
+[ERROR] /path/to/ComplexError.java:[41,10] cannot find symbol
+  symbol:   variable undefinedVar
+  location: class ComplexError
+[INFO] 2 errors
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 2, "Expected two errors.")
+        # First error
+        error1 = errors[0]
+        self.assertIsInstance(error1, TypeMismatchError)
+        self.assertEqual(error1.file, "/path/to/ComplexError.java")
+        self.assertEqual(error1.line, 40)
+        self.assertEqual(error1.column, 22)
+        self.assertEqual(
+            error1.message, "incompatible types: int cannot be converted to String"
+        )
+        # Second error
+        error2 = errors[1]
+        self.assertIsInstance(error2, SymbolNotFoundError)
+        self.assertEqual(error2.file, "/path/to/ComplexError.java")
+        self.assertEqual(error2.line, 41)
+        self.assertEqual(error2.column, 10)
+        self.assertEqual(error2.missing_symbol, "variable undefinedVar")
+        self.assertEqual(error2.symbol_location, "class ComplexError")
+
+    def test_error_with_no_line_column(self):
+        # Test case where the error line does not contain line and column numbers
+        maven_output = """
+[ERROR] COMPILATION ERROR :
+[ERROR] /path/to/UnknownLocation.java: cannot find symbol
+  symbol:   class UnknownClass
+[INFO] 1 error
+[INFO] -------------------------------------------------------------
+[ERROR] BUILD FAILURE
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        # Since the error_pattern requires line and column, this error may not be parsed.
+        # Adjust the regex pattern if needed.
+        self.assertEqual(
+            len(errors), 1, "Expected one error despite missing line and column."
+        )
+        error = errors[0]
+        self.assertIsInstance(error, SymbolNotFoundError)
+        self.assertEqual(error.file, "/path/to/UnknownLocation.java")
+        self.assertEqual(error.line, -1)
+        self.assertEqual(error.column, -1)
+        self.assertEqual(error.missing_symbol, "class UnknownClass")
+
+    def test_build_error_with_multiple_projects(self):
+        # Test case with build errors in a multi-module project
+        maven_output = """
+[ERROR] Some problems were encountered while processing the POMs:
+[FATAL] Non-resolvable parent POM for com.example:module1:1.0-SNAPSHOT: Could not find artifact com.example:parent:pom:1.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 5, column 13
+[ERROR] The build could not read 1 project -> [Help 1]
+[ERROR]   The project com.example:module1:1.0-SNAPSHOT (/path/to/module1/pom.xml) has 1 error
+[ERROR]     Non-resolvable parent POM for com.example:module1:1.0-SNAPSHOT: Could not find artifact com.example:parent:pom:1.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 5, column 13 -> [Help 2]
+"""
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        # Assuming deduplication is implemented
+        self.assertEqual(len(errors), 1, "Expected one unique build error.")
+        error = errors[0]
+        self.assertIsInstance(error, BuildError)
+        self.assertEqual(error.file, "/path/to/module1/pom.xml")
+        self.assertEqual(error.line, 5)
+        self.assertEqual(error.column, 13)
+        self.assertIn("Non-resolvable parent POM", error.message)
+
+    def test_dependency_resolution_error(self):
+        maven_output = """
+    [INFO] Scanning for projects...
+    [INFO]
+    [INFO] -------------------< com.redhat.coolstore:monolith >--------------------
+    [INFO] Building coolstore-monolith 1.0.0-SNAPSHOT
+    [INFO]   from pom.xml
+    [INFO] --------------------------------[ jar ]---------------------------------
+    Downloading from github: https://maven.pkg.github.com/shawn-hurley/analyzer-lsp/jakarta/jakarta.jakartaee-web-api/8.0.0/jakarta.jakartaee-web-api-8.0.0.pom
+    Downloading from github: https://maven.pkg.github.com/shawn-hurley/analyzer-lsp/jakarta/jakarta.jakartaee-api/8.0.0/jakarta.jakartaee-api-8.0.0.pom
+    [INFO] ------------------------------------------------------------------------
+    [INFO] BUILD FAILURE
+    [INFO] ------------------------------------------------------------------------
+    [INFO] Total time:  2.296 s
+    [INFO] Finished at: 2024-11-13T14:02:10-05:00
+    [INFO] ------------------------------------------------------------------------
+    [ERROR] Failed to execute goal on project monolith: Could not resolve dependencies for project com.redhat.coolstore:monolith:jar:1.0.0-SNAPSHOT: Failed to collect dependencies at jakarta:jakarta.jakartaee-web-api:jar:8.0.0: ...
+    [ERROR]
+    [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+    [ERROR] Re-run Maven using the -X switch to enable full debug logging.
+    [ERROR]
+    [ERROR] For more information about the errors and possible solutions, please read the following articles:
+    [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
+    """
+        rc = 1
+        errors = parse_maven_output(maven_output, rc)
+        self.assertEqual(len(errors), 1, "Expected one dependency resolution error.")
+        error = errors[0]
+        self.assertIsInstance(error, DependencyResolutionError)
+        self.assertEqual(error.file, "pom.xml")
+        self.assertEqual(error.line, -1)
+        self.assertEqual(error.column, -1)
+        self.assertEqual(error.project, "monolith")
+        self.assertEqual(error.goal, "")
+        self.assertIn("Could not resolve dependencies", error.message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Introduces two new error types, `BuildError` and `DependencyResolutionError`, which are now detected and parsed
- Adds a catchall condition if maven exits non-zero but no errors are successfully parsed so that we have a chance at solving the issue
- Restructures the maven_validator as the parsing logic was getting unwieldy
- The maven task_runner no longer adds whitespace at the top of files
- The dependency task_runner now properly checks the tasks it can handle
- Adds tests for maven validator
