### PR TITLE
:sparkles: Seeds tasks can now be set at any time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ KAI__DEMO_MODE ?= False
 DROP_TABLES ?= False
 HUB_URL ?= ""
 IMPORTER_ARGS ?= ""
-POSTGRES_RUN_ARGS ?= 
+POSTGRES_RUN_ARGS ?=
 
 run-postgres:
 	$(CONTAINER_RUNTIME) run -it $(POSTGRES_RUN_ARGS) -v data:/var/lib/postgresql/data -e POSTGRES_USER=kai -e POSTGRES_PASSWORD=dog8code -e POSTGRES_DB=kai -p 5432:5432 docker.io/library/postgres:16.3
@@ -30,12 +30,12 @@ build-kai-analyzer:
 	cd kai_analyzer_rpc && go build -o kai-analyzer main.go
 
 build-kai-rpc-server:
-	pyinstaller build/build.spec
+	pyinstaller --clean build/build.spec
 
 set_up_run_demo:
 	mv dist/kai-rpc-server example/analysis/kai-rpc-server
-	mv kai_analyzer_rpc/kai-analyzer example/analysis/kai-analyzer-rpc 
-	
+	mv kai_analyzer_rpc/kai-analyzer example/analysis/kai-analyzer-rpc
+
 get_analyzer_deps:
 	docker run -d --name=bundle quay.io/konveyor/jdtls-server-base:latest &&\
     docker cp bundle:/usr/local/etc/maven.default.index ./example/analysis &&\
@@ -43,9 +43,9 @@ get_analyzer_deps:
     docker cp bundle:/jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar ./example/analysis/bundle.jar &&\
     docker cp bundle:/usr/local/etc/maven.default.index ./example/analysis &&\
 	docker stop bundle &&\
-	docker rm bundle 
+	docker rm bundle
 
 get_rulesets:
-	cd example/analysis && git clone https://github.com/konveyor/rulesets && rm -rf rulesets/preview
+	(cd example/analysis && git clone https://github.com/konveyor/rulesets); rm -rf example/analysis/rulesets/preview
 
 config_demo: build-kai-analyzer build-kai-rpc-server set_up_run_demo get_analyzer_deps get_rulesets

--- a/kai/reactive_codeplanner/task_manager/priority_queue.py
+++ b/kai/reactive_codeplanner/task_manager/priority_queue.py
@@ -13,14 +13,30 @@ class PriorityTaskQueue:
 
     def push(self, task: Task) -> None:
         for priority_level, task_stack in self.task_stacks.items():
-            if task in task_stack:
-                logger.debug(
-                    "Task %s already exists in priority %s stack. Existing task takes precedence.",
-                    task,
-                    priority_level,
-                )
-                # Existing task takes precedence; do not add or modify
-                return
+            try:
+                idx = task_stack.index(task)
+                existing_task = task_stack[idx]
+                if existing_task.priority > task.priority:
+                    # Accept the new priority level
+                    existing_task.priority = task.priority
+                    # Overwrite with the existing task since it could carry history with it
+                    task = task_stack.pop(idx)
+                    logger.debug(
+                        "Task %s already exists in priority %s stack. New task takes precedence.",
+                        task,
+                        priority_level,
+                    )
+                    break
+                else:
+                    logger.debug(
+                        "Task %s already exists in priority %s stack. Existing task takes precedence.",
+                        task,
+                        priority_level,
+                    )
+                    # Existing task takes precedence; do not add or modify
+                    return
+            except ValueError:
+                continue
 
         priority = task.oldest_ancestor().priority
         if priority not in self.task_stacks:


### PR DESCRIPTION
- Adds `set_seed_tasks` method to `TaskManager`, which replaces the current set of seed tasks with a new one
- The server now initializes the `TaskManager` only once, and maintains queue state between calls. The `set_seed_tasks` method is used to reset the top-level priority queue.
- Removes `max_iterations` from inside the `task_manager`. Instead, the caller of `get_next_task` can maintain the iterations outside the loop. The rpc server has been updated to handle this.
- Changes `run_demo` default `max_iterations` to the number of incidents in a file
- Adds more logging throughout the server + demo to better aid debugging, particularly when the process hangs
- Adds/refines make targets for running the demos + debug driver more consistently
- Sets the default analysis rules path to `default/generated`, preventing a hang when the dotnet rules are accidentally included