### PR TITLE
:bug: Moved solution server dependencies out from main dependency block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ dependencies = [
   "requests==2.32.3",
   "pygments==2.18.0",
   "python-dateutil==2.8.2",
-  "sqlalchemy==2.0.22",
-  "psycopg2-binary==2.9.9",
   "ibm-generative-ai==2.2.0",
   "Jinja2==3.1.4",
   "langchain==0.3.1",
@@ -64,8 +62,6 @@ dependencies = [
   "typer==0.9.0",         # For potential CLI stuff
   "loguru==0.7.2",        # For potential logging improvements
   "unidiff==0.7.5",
-
-  "imgui[sdl2]",
 ]
 requires-python = ">=3.11"
 authors = [
@@ -88,6 +84,8 @@ dev = [
   "types-Pygments",
   "lxml-stubs==0.5.1",
 ]
+
+solution_server = ["sqlalchemy==2.0.22", "psycopg2-binary==2.9.9"]
 
 [project.urls]
 Repository = "https://www.github.com/konveyor/kai"


### PR DESCRIPTION
This should hopefully fix some issues that people are having when trying to run Kai on MacOS.