### PR TITLE
:bug: Fix for #478 KeyError: 'latestVersion'

### DIFF
--- a/kai/reactive_codeplanner/agent/dependency_agent/util.py
+++ b/kai/reactive_codeplanner/agent/dependency_agent/util.py
@@ -26,23 +26,24 @@ def search_fqdn_query(query: str) -> Optional[FQDNResponse] | list[FQDNResponse]
         ### context.
         all_found_deps = []
         for d in docs:
-            if 'latestVersion' in d:
+            if "latestVersion" in d:
                 all_found_deps.append(
                     FQDNResponse(
                         artifact_id=d["a"], group_id=d["g"], version=d["latestVersion"]
+                    )
                 )
-            )
         return all_found_deps if all_found_deps else None
     else:
         doc = docs[0]
 
-        if 'latestVersion' in doc:
+        if "latestVersion" in doc:
 
             return FQDNResponse(
                 artifact_id=doc["a"], group_id=doc["g"], version=doc["latestVersion"]
             )
-        
+
         return None
+
 
 def search_fqdn(code: str) -> Optional[FQDNResponse] | list[FQDNResponse]:
     query = get_maven_query_from_code(code)

--- a/kai/reactive_codeplanner/agent/dependency_agent/util.py
+++ b/kai/reactive_codeplanner/agent/dependency_agent/util.py
@@ -26,18 +26,23 @@ def search_fqdn_query(query: str) -> Optional[FQDNResponse] | list[FQDNResponse]
         ### context.
         all_found_deps = []
         for d in docs:
-            all_found_deps.append(
-                FQDNResponse(
-                    artifact_id=d["a"], group_id=d["g"], version=d["latestVersion"]
+            if 'latestVersion' in d:
+                all_found_deps.append(
+                    FQDNResponse(
+                        artifact_id=d["a"], group_id=d["g"], version=d["latestVersion"]
                 )
             )
-        return all_found_deps
+        return all_found_deps if all_found_deps else None
     else:
         doc = docs[0]
-        return FQDNResponse(
-            artifact_id=doc["a"], group_id=doc["g"], version=doc["latestVersion"]
-        )
 
+        if 'latestVersion' in doc:
+
+            return FQDNResponse(
+                artifact_id=doc["a"], group_id=doc["g"], version=doc["latestVersion"]
+            )
+        
+        return None
 
 def search_fqdn(code: str) -> Optional[FQDNResponse] | list[FQDNResponse]:
     query = get_maven_query_from_code(code)


### PR DESCRIPTION
Fix Maven Central FQDN Search for Dependency Agent
- Handle Maven Central search responses without latest version
- Return None when no valid dependency version is found
