### PR TITLE
:ghost: make release workflow callable

### DIFF
--- a/.github/workflows/build-and-push-binaries.yml
+++ b/.github/workflows/build-and-push-binaries.yml
@@ -40,6 +40,31 @@ env:
       { "os": "ubuntu-24.04-arm", "shell": "bash" }
     ]
 jobs:
+  # these are specific java artifacts (cross-platform) that we
+  # download on linux and re-use on other platforms
+  download_artifacts:
+    name: Download cross-platform java dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          repository: konveyor/kai
+      
+      - name: Download deps
+        run: |
+          git config --global user.email "no-reply@konveyor.io"
+          git config --global user.name "Konveyor CI"
+          make get-analyzer-deps
+          make get-rulesets
+          cd example/analysis && zip -r java-deps.zip maven.default.index jdtls bundle.jar rulesets
+      
+      - name: Upload deps as temp artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-deps.zip
+          path: ./example/analysis/java-deps.zip
+
   # this job exists because we want to store the build matrix as output
   # it will be used in the subsequent job as well as in a "calling" workflow
   share_matrix_info:
@@ -57,7 +82,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   e2e_test:
-    needs: share_matrix_info
+    needs:
+    - share_matrix_info
+    - download_artifacts
     name: Run e2e test
     strategy:
       matrix:
@@ -137,21 +164,28 @@ jobs:
         run: |
           cd kai_analyzer_rpc; go build -ldflags="-extldflags=-static" -o kai-analyzer-rpc main.go; cd ..
 
-      - name: Setup analysis deps
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: java-deps.zip
+
+      - name: Setup analysis deps (linux & mac)
+        if: ${{ ! startsWith(matrix.runs_on.os, 'windows') }}
+        run: |
+          unzip java-deps.zip -d java-deps
+          cp -r java-deps/* ./example/analysis
+  
+      - name: Setup analysis deps (windows)
+        if: ${{ startsWith(matrix.runs_on.os, 'windows') }}
+        run: |
+          Expand-Archive -Path java-deps.zip -DestinationPath java-deps
+
+      - name: Run e2e test
         if: ${{ startsWith(matrix.runs_on.os, 'ubuntu') }}
         run: |
           cp ./dist/kai-rpc-server ./example/analysis/
           cp ./kai_analyzer_rpc/kai-analyzer-rpc ./example/analysis/
-          docker run -d --name=bundle quay.io/konveyor/jdtls-server-base:latest
-          docker cp bundle:/usr/local/etc/maven.default.index ./example/analysis
-          docker cp bundle:/jdtls ./example/analysis
-          docker cp bundle:/jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar ./example/analysis/bundle.jar
-          docker cp bundle:/usr/local/etc/maven.default.index ./example/analysis
-          git config --global user.email "no-reply@konveyor.io"
-          git config --global user.name "Konveyor CI"
-          git clone https://github.com/konveyor/rulesets
-          mv ./rulesets ./example/analysis/rulesets
-
+          
           cat << EOF > ./example/config.toml
           log_level = "info"
           file_log_level = "debug"
@@ -169,10 +203,7 @@ jobs:
           EOF
           fi
           cat ./example/config.toml
-
-      - name: Run e2e test
-        if: ${{ startsWith(matrix.runs_on.os, 'ubuntu') }}
-        run: |
+          
           which python
           cd example
           ./fetch.sh
@@ -218,13 +249,14 @@ jobs:
       - name: Archive binaries (linux & mac)
         if: ${{ ! startsWith(matrix.runs_on.os, 'windows') }}
         run: |
-          zip -j kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }}.zip dist/kai-rpc-server kai_analyzer_rpc/kai-analyzer-rpc
+          zip -j kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }}.zip dist/kai-rpc-server kai_analyzer_rpc/kai-analyzer-rpc ./example/analysis/maven.default.index ./example/analysis/bundle.jar 
+          zip -r kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }} ./example/analysis/jdtls ./example/analysis/rulesets
 
       - name: Archive binaries (windows)
         if: ${{ startsWith(matrix.runs_on.os, 'windows') }}
         run: |
           mv kai_analyzer_rpc\kai-analyzer-rpc kai_analyzer_rpc\kai-analyzer-rpc.exe
-          $filesToInclude = "dist\kai-rpc-server.exe", "kai_analyzer_rpc\kai-analyzer-rpc.exe"
+          $filesToInclude = "dist\kai-rpc-server.exe", "kai_analyzer_rpc\kai-analyzer-rpc.exe", "java-deps\maven.default.index", "java-deps\rulesets", "java-deps\bundle.jar", "java-deps\jdtls"
           Compress-Archive -Path $filesToInclude -Destination kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }}.zip
 
       - name: Upload binary

--- a/.github/workflows/build-and-push-binaries.yml
+++ b/.github/workflows/build-and-push-binaries.yml
@@ -1,6 +1,7 @@
 name: Build and Publish Binaries
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       use_latest_release:
@@ -39,10 +40,14 @@ jobs:
           - provider: ChatIBMGenAI
             model_id: meta-llama/llama-3-1-70b-instruct
             max_new_tokens: 2048
+    outputs:
+      runs_on_info: ${{ toJson(matrix.runs_on) }}
     runs-on: ${{ matrix.runs_on.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          repository: konveyor/kai
 
       - uses: actions/setup-java@v3
         if: ${{ ! startsWith(matrix.runs_on.os, 'windows') }}
@@ -57,6 +62,7 @@ jobs:
           java-version: "17"
 
       - id: release_info
+        if: github.event_name == 'workflow_dispatch'
         uses: joutvhu/get-release@v1
         with:
           latest: ${{ github.event.inputs.use_latest_release }}
@@ -209,7 +215,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload binaries as artifact
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_call'
         uses: actions/upload-artifact@v4
         with:
           name: kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }}.zip

--- a/.github/workflows/build-and-push-binaries.yml
+++ b/.github/workflows/build-and-push-binaries.yml
@@ -2,8 +2,16 @@ name: Build and Publish Binaries
 
 on:
   workflow_call:
+    outputs:
+      matrix_info:
+        description: List of os / arch information in the build matrix
+        value: ${{ jobs.share_matrix_info.outputs.matrix_info }}
   workflow_dispatch:
     inputs:
+      publish_artifacts_to_release:
+        type: boolean
+        default: true
+        description: Upload binaries to an existing github release. When not set, binaries will be uploaded as temporary github artifacts.
       use_latest_release:
         type: boolean
         default: true
@@ -18,30 +26,46 @@ on:
         default: false
   pull_request:
   push:
+
+# the build matrix exists as an env var so that we can
+# share that info reliably with the "calling" workflow
+env:
+  BUILD_MATRIX: | 
+    [ 
+      { "os": "ubuntu-latest", "shell": "bash" },
+      { "os": "macos-latest", "shell": "bash" },
+      { "os": "macos-13", "shell": "bash" },
+      { "os": "windows-latest", "shell": "cmd" },
+      { "os": "windows-11-preview-arm", "shell": "cmd" },
+      { "os": "ubuntu-24.04-arm", "shell": "bash" }
+    ]
 jobs:
+  # this job exists because we want to store the build matrix as output
+  # it will be used in the subsequent job as well as in a "calling" workflow
+  share_matrix_info:
+    name: Output platform info
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_info: ${{ steps.matrix_info.outputs.matrix_info }}
+    steps:
+      - id: matrix_info
+        run: |
+          { 
+            echo 'matrix_info<<EOF'
+            echo '${{ env.BUILD_MATRIX }}'
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
   e2e_test:
+    needs: share_matrix_info
     name: Run e2e test
     strategy:
       matrix:
-        runs_on:
-          - os: ubuntu-latest
-            shell: bash
-          - os: macos-latest
-            shell: bash
-          - os: macos-13
-            shell: bash
-          - os: windows-latest
-            shell: cmd
-          - os: windows-11-preview-arm
-            shell: cmd
-          - os: ubuntu-24.04-arm
-            shell: bash
+        runs_on: ${{ fromJson(needs.share_matrix_info.outputs.matrix_info) }}
         models:
           - provider: ChatIBMGenAI
             model_id: meta-llama/llama-3-1-70b-instruct
             max_new_tokens: 2048
-    outputs:
-      runs_on_info: ${{ toJson(matrix.runs_on) }}
     runs-on: ${{ matrix.runs_on.os }}
     steps:
       - name: Checkout code
@@ -62,7 +86,7 @@ jobs:
           java-version: "17"
 
       - id: release_info
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event.inputs.publish_artifacts_to_release || false }}
         uses: joutvhu/get-release@v1
         with:
           latest: ${{ github.event.inputs.use_latest_release }}
@@ -204,7 +228,7 @@ jobs:
           Compress-Archive -Path $filesToInclude -Destination kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }}.zip
 
       - name: Upload binary
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event.inputs.publish_artifacts_to_release || false }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -215,7 +239,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload binaries as artifact
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_call'
+        if: ${{ !github.event.inputs.publish_artifacts_to_release || true }}
         uses: actions/upload-artifact@v4
         with:
           name: kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }}.zip

--- a/.github/workflows/build-and-push-binaries.yml
+++ b/.github/workflows/build-and-push-binaries.yml
@@ -183,11 +183,14 @@ jobs:
       - name: Run e2e test
         if: ${{ startsWith(matrix.runs_on.os, 'ubuntu') }}
         run: |
+          git config --global user.email "no-reply@konveyor.io"
+          git config --global user.name "Konveyor CI"
+
           cp ./dist/kai-rpc-server ./example/analysis/
           cp ./kai_analyzer_rpc/kai-analyzer-rpc ./example/analysis/
-          
+
           cat << EOF > ./example/config.toml
-          log_level = "info"
+          log_level = "debug"
           file_log_level = "debug"
           log_dir = "/home/runner/work/kai/kai/kai/../../logs/"
           demo_mode = true


### PR DESCRIPTION
Fixes #520 

Here is an example of a calling workflow that can use this workflow. It runs this workflow to build Kai binaries for all platforms and does its own things on the same platforms:

```
name: test

on:
  workflow_dispatch:

jobs:
  kai_build:
    uses: konveyor/kai/.github/workflows/build-and-push-binaries.yml@main

  plugin_build:
    name: plugin build
    needs: kai_build
    strategy:
      matrix:
        runs_on: ${{ fromJson(needs.kai_build.outputs.matrix_info) }}
    runs-on: ${{ matrix.runs_on.os }}
    steps:
      - name: Download kai binaries
        uses: actions/download-artifact@v3
        with:
          name: kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }}.zip
          path: kai-rpc-server.${{ env.OS }}-${{ env.OS_ARCH }}.zip
      - name: Build and package the IDE plugin
        run: | 
          # do whatever you need to do to build your own thing
```