### PR TITLE
:ghost: Fixing types for mypy

### DIFF
--- a/kai/analyzer_types.py
+++ b/kai/analyzer_types.py
@@ -7,7 +7,7 @@ import pathlib
 import shutil
 from collections.abc import KeysView
 from enum import StrEnum
-from io import StringIO, TextIOWrapper
+from io import StringIO
 from pathlib import Path
 from typing import Any, Iterator, Optional
 from urllib.parse import urlparse
@@ -335,7 +335,7 @@ class Report:
 
     # TODO: Migrate to a jinja template
     def _write_markdown_snippet(
-        self, ruleset_name: str, ruleset: RuleSet, f: TextIOWrapper
+        self, ruleset_name: str, ruleset: RuleSet, f: StringIO
     ) -> None:
         f.write(f"# {ruleset_name}\n")
         f.write("## Description\n")


### PR DESCRIPTION
Fixing types for mypy

StringIO does not type to TextIOWrapper[_BufferedWrapper], there is no issue using StringIO AFAICT so just using that