### PR TITLE
:bug: Ensure Kai RPC Server Stops When Analyzer-LSP-RPC Fails 

### DIFF
--- a/kai/analyzer.py
+++ b/kai/analyzer.py
@@ -62,31 +62,41 @@ class AnalyzerLSP:
             args.append(str(dep_open_source_labels_path))
         logger.debug(f"Starting analyzer rpc server with {args}")
 
-        self.rpc_server = subprocess.Popen(
-            args,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=ENV,
-        )
-        # trunk-ignore-end(bandit/B603)
-        self.excluded_paths = excluded_paths
+        try:
+            self.rpc_server = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=ENV,
+            )
 
-        self.stderr_logging_thread = threading.Thread(
-            target=log_stderr, args=(self.rpc_server.stderr,)
-        )
-        self.stderr_logging_thread.start()
+            if self.rpc_server.poll() is not None:
+                self.stop()
+                raise Exception("Analyzer failed to start: process exited immediately")
 
-        self.rpc = JsonRpcServer(
-            json_rpc_stream=BareJsonStream(
-                cast(BufferedReader, self.rpc_server.stdout),
-                cast(BufferedWriter, self.rpc_server.stdin),
-            ),
-            request_timeout=4 * 60,
-            log=get_logger("kai.analyzer-rpc-client"),
-        )
-        self.rpc.start()
-        logger.debug("analyzer rpc server started")
+            # trunk-ignore-end(bandit/B603)
+            self.excluded_paths = excluded_paths
+
+            self.stderr_logging_thread = threading.Thread(
+                target=log_stderr, args=(self.rpc_server.stderr,)
+            )
+            self.stderr_logging_thread.start()
+
+            self.rpc = JsonRpcServer(
+                json_rpc_stream=BareJsonStream(
+                    cast(BufferedReader, self.rpc_server.stdout),
+                    cast(BufferedWriter, self.rpc_server.stdin),
+                ),
+                request_timeout=4 * 60,
+                log=get_logger("kai.analyzer-rpc-client"),
+            )
+            self.rpc.start()
+            logger.debug("analyzer rpc server started")
+
+        except Exception as e:
+            self.stop()
+            raise Exception(f"Analyzer failed to start: {str(e)}")
 
     def run_analyzer_lsp(
         self,

--- a/kai/analyzer.py
+++ b/kai/analyzer.py
@@ -96,7 +96,7 @@ class AnalyzerLSP:
 
         except Exception as e:
             self.stop()
-            raise Exception(f"Analyzer failed to start: {str(e)}")
+            raise Exception(f"Analyzer failed to start: {str(e)}") from e
 
     def run_analyzer_lsp(
         self,

--- a/kai/rpc_server/server.py
+++ b/kai/rpc_server/server.py
@@ -198,6 +198,7 @@ def initialize(
                 analyzer_lsp_path=app.config.analyzer_lsp_lsp_path,
                 dep_open_source_labels_path=app.config.analyzer_lsp_dep_labels_path
                 or Path(),
+                excluded_paths=app.config.analyzer_lsp_excluded_paths,
             )
         except Exception as e:
             server.shutdown_flag = True

--- a/kai/rpc_server/server.py
+++ b/kai/rpc_server/server.py
@@ -189,17 +189,26 @@ def initialize(
 
         app.log.info(f"Initialized with config: {app.config}")
 
-        app.analyzer = AnalyzerLSP(
-            analyzer_lsp_server_binary=app.config.analyzer_lsp_rpc_path,
-            repo_directory=app.config.root_path,
-            rules=app.config.analyzer_lsp_rules_paths,
-            java_bundles=app.config.analyzer_lsp_java_bundle_paths,
-            analyzer_lsp_path=app.config.analyzer_lsp_lsp_path,
-            dep_open_source_labels_path=app.config.analyzer_lsp_dep_labels_path
-            or Path(),
-            excluded_paths=app.config.analyzer_lsp_excluded_paths,
-        )
-
+        try:
+            app.analyzer = AnalyzerLSP(
+                analyzer_lsp_server_binary=app.config.analyzer_lsp_rpc_path,
+                repo_directory=app.config.root_path,
+                rules=app.config.analyzer_lsp_rules_paths,
+                java_bundles=app.config.analyzer_lsp_java_bundle_paths,
+                analyzer_lsp_path=app.config.analyzer_lsp_lsp_path,
+                dep_open_source_labels_path=app.config.analyzer_lsp_dep_labels_path
+                or Path(),
+            )
+        except Exception as e:
+            server.shutdown_flag = True
+            server.send_response(
+                id=id,
+                error=JsonRpcError(
+                    code=JsonRpcErrorCode.InternalError,
+                    message=str(e),
+                ),
+            )
+            return
         internal_config = RpcClientConfig(
             repo_directory=app.config.root_path,
             analyzer_lsp_server_binary=app.config.analyzer_lsp_rpc_path,


### PR DESCRIPTION
I have tried to Implement exception handling in analyzer initialization to:
- Detect analyzer startup failures
- Stop RPC server when analyzer cannot start

Solves #537 