### PR TITLE
:sparkles: package/symbol not found errors are now collapsable for file

### DIFF
--- a/kai/reactive_codeplanner/agent/dependency_agent/dependency_agent.py
+++ b/kai/reactive_codeplanner/agent/dependency_agent/dependency_agent.py
@@ -150,8 +150,10 @@ When completed, add Final Answer that tells the steps taken
 
 If you are at the point of editing, add the final answer of what you did
 
-Message:{message}
-    """
+Message:
+
+    {message}
+"""
     )
 
     AgentMethods = TypedDict(

--- a/kai/reactive_codeplanner/agent/maven_compiler_fix/agent.py
+++ b/kai/reactive_codeplanner/agent/maven_compiler_fix/agent.py
@@ -2,11 +2,14 @@ from jinja2 import Template
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from kai.llm_interfacing.model_provider import ModelProvider
+from kai.logging.logging import get_logger
 from kai.reactive_codeplanner.agent.api import Agent, AgentRequest, AgentResult
 from kai.reactive_codeplanner.agent.maven_compiler_fix.api import (
     MavenCompilerAgentRequest,
     MavenCompilerAgentResult,
 )
+
+logger = get_logger(__name__)
 
 
 class MavenCompilerAgent(Agent):
@@ -54,7 +57,13 @@ class MavenCompilerAgent(Agent):
         if not isinstance(ask, MavenCompilerAgentRequest):
             return AgentResult()
 
-        line_of_code = ask.file_contents.split("\n")[ask.line_number]
+        try:
+            line_of_code = ask.file_contents.split("\n")[ask.line_number]
+        except Exception:
+            logger.exception(
+                "unable to  split file contents and get line from linenumber"
+            )
+            return MavenCompilerAgentResult()
 
         compile_errors = f"Line of code: {line_of_code};\n{ask.message}"
         content = self.chat_message_template.render(

--- a/kai/reactive_codeplanner/task_runner/analyzer_lsp/api.py
+++ b/kai/reactive_codeplanner/task_runner/analyzer_lsp/api.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, List
+from typing import Any
 
 from kai.analyzer_types import Incident, RuleSet, Violation
 from kai.logging.logging import TRACE, get_logger
@@ -11,7 +11,7 @@ logger = get_logger(__name__)
 
 @dataclass(eq=False, kw_only=True)
 class AnalyzerRuleViolation(ValidationError):
-    incidents: List[Incident]
+    incidents: list[Incident]
 
     # NOTE(JonahSussman): Violation contains a list of Incidents, and RuleSet
     # contains a list of Violations. We have another class, ExtendedIncident,

--- a/kai/reactive_codeplanner/task_runner/compiler/compiler_task_runner.py
+++ b/kai/reactive_codeplanner/task_runner/compiler/compiler_task_runner.py
@@ -86,7 +86,7 @@ class MavenCompilerTaskRunner(TaskRunner):
                 task,
                 src_file_contents,
                 task.line,
-                task.message,
+                task.compiler_error_message(),
             )
         )
 

--- a/kai/rpc_server/server.py
+++ b/kai/rpc_server/server.py
@@ -509,14 +509,13 @@ def get_codeplan_agent_solution(
 
         params.incidents.sort()
         grouped_incidents_by_files = [
-            list((g)) for _, g in groupby(params.incidents, key=attrgetter("uri"))
+            list(g) for _, g in groupby(params.incidents, key=attrgetter("uri"))
         ]
         for incidents in grouped_incidents_by_files:
 
             # group incidents by violation
             grouped_violations = [
-                list((g))
-                for _, g in groupby(incidents, key=attrgetter("violation_name"))
+                list(g) for _, g in groupby(incidents, key=attrgetter("violation_name"))
             ]
             for violation_incidents in grouped_violations:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "lxml==5.3.0",
   "boto3==1.36.9",                            # Allows Amazon Bedrock to work
   "pylspclient==0.1.2",                       # used for talking to RPC clients over stdin/stdout
-  "opentelemetry-sdk",
+  "opentelemetry-sdk==1.29.0",
   "opentelemetry-api",
   "opentelemetry-exporter-otlp",
   "opentelemetry-instrumentation-threading",


### PR DESCRIPTION
* This also adds the clean option to maven, so that maven is recompiled every time; this is needed when the pom.xml does not yet have the maven compiler plugin.
* The line numbers are not used in the dependency agent; because of this, we can assume we know that we don't need to pass it through.