### PR TITLE
:bug: Fixed default params for openai

### DIFF
--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -57,6 +57,28 @@ class ModelProvider:
             case "ChatOpenAI":
                 model_class = ChatOpenAI
 
+                # NOTE(JonahSussman): This is a hack to prevent `max_tokens`
+                # from getting converted to `max_completion_tokens`
+
+                @property
+                def _default_params(self: ChatOpenAI) -> dict[str, Any]:
+                    return super(ChatOpenAI, self)._default_params
+
+                ChatOpenAI._default_params = _default_params
+
+                def _get_request_payload(
+                    self: ChatOpenAI,
+                    input_: LanguageModelInput,
+                    *,
+                    stop: list[str] | None = None,
+                    **kwargs: Any,
+                ) -> dict:
+                    return super(ChatOpenAI, self)._get_request_payload(
+                        input_, stop=stop, **kwargs
+                    )
+
+                ChatOpenAI._get_request_payload = _get_request_payload
+
                 defaults = {
                     "model": "gpt-3.5-turbo",
                     "temperature": 0.1,

--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -60,11 +60,11 @@ class ModelProvider:
                 # NOTE(JonahSussman): This is a hack to prevent `max_tokens`
                 # from getting converted to `max_completion_tokens`
 
-                @property
+                @property  # type: ignore[misc]
                 def _default_params(self: ChatOpenAI) -> dict[str, Any]:
                     return super(ChatOpenAI, self)._default_params
 
-                ChatOpenAI._default_params = _default_params
+                ChatOpenAI._default_params = _default_params  # type: ignore[method-assign]
 
                 def _get_request_payload(
                     self: ChatOpenAI,
@@ -72,12 +72,12 @@ class ModelProvider:
                     *,
                     stop: list[str] | None = None,
                     **kwargs: Any,
-                ) -> dict:
+                ) -> dict:  # type: ignore[type-arg]
                     return super(ChatOpenAI, self)._get_request_payload(
                         input_, stop=stop, **kwargs
                     )
 
-                ChatOpenAI._get_request_payload = _get_request_payload
+                ChatOpenAI._get_request_payload = _get_request_payload  # type: ignore[method-assign]
 
                 defaults = {
                     "model": "gpt-3.5-turbo",

--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -193,7 +193,10 @@ class ModelProvider:
         if isinstance(self.llm, ChatOllama):
             challenge("max_tokens")
         elif isinstance(self.llm, ChatOpenAI):
-            challenge("max_tokens")
+            try:
+                challenge("max_tokens")
+            except Exception:
+                challenge("max_completion_tokens")
         elif isinstance(self.llm, ChatBedrock):
             challenge("max_tokens")
         elif isinstance(self.llm, FakeListChatModel):


### PR DESCRIPTION
The default implementation of `_default_params` and `_get_request_payload` on `ChatOpenAI` automatically converts `max_completion_tokens` to `max_tokens`, which is undesirable for certain OpenShift AI instances.

[link](https://github.com/langchain-ai/langchain/blob/db8201d4dafb533133cc51c87c7ef011e546e03f/libs/partners/openai/langchain_openai/chat_models/base.py#L1992-L2013)

```python
@property
def _default_params(self) -> Dict[str, Any]:
    """Get the default parameters for calling OpenAI API."""
    params = super()._default_params
    if "max_tokens" in params:
        params["max_completion_tokens"] = params.pop("max_tokens")

    return params

def _get_request_payload(
    self,
    input_: LanguageModelInput,
    *,
    stop: Optional[List[str]] = None,
    **kwargs: Any,
) -> dict:
    payload = super()._get_request_payload(input_, stop=stop, **kwargs)
    # max_tokens was deprecated in favor of max_completion_tokens
    # in September 2024 release
    if "max_tokens" in payload:
        payload["max_completion_tokens"] = payload.pop("max_tokens")
    return payload
```