### PR TITLE
:sparkles: Replace max_iterations with max_llm_calls

### DIFF
--- a/kai/kai_config.py
+++ b/kai/kai_config.py
@@ -166,6 +166,7 @@ class KaiConfigModels(BaseModel):
     llama_header: Optional[bool] = Field(default=None)
     llm_retries: int = 5
     llm_retry_delay: float = 10.0
+    llm_call_budget: int = -1
 
 
 # Main config


### PR DESCRIPTION
- Add a counter to the model provider to optionally limit the number of requests that can be made.
- Remove all references to max_iterations (except for in the rpc_server params, we can remove that in a few releases)