### PR TITLE
:bug: fix cache paths when they become too long to handle

### DIFF
--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -247,11 +247,16 @@ class ModelProvider:
 
         response = invoke_llm.invoke(input, config, stop=stop, **kwargs)
 
-        self.cache.put(
-            path=cache_path,
-            input=input,
-            output=response,
-            cache_meta=cache_meta,
-        )
+        try:
+            self.cache.put(
+                path=cache_path,
+                input=input,
+                output=response,
+                cache_meta=cache_meta,
+            )
+        except Exception as e:
+            # only raise an exception when we are in demo mode
+            if self.demo_mode:
+                raise e
 
         return response


### PR DESCRIPTION
Fixes #636 
This makes it so that when paths become too long, they are flattened at the root task's level, so we still get hierarchy as much as we can but leave the too many nested stuff flattened which is probably pita to navigate anyway