### PR TITLE
:sparkles: Adding cache file name resolution to the task's

### DIFF
--- a/kai/cache.py
+++ b/kai/cache.py
@@ -1,5 +1,4 @@
 import platform
-import re
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Optional
@@ -12,7 +11,6 @@ from langchain_core.prompt_values import PromptValue
 from kai.jsonrpc.util import AutoAbsPath
 from kai.logging.logging import TRACE, get_logger
 from kai.reactive_codeplanner.task_manager.api import Task, ValidationError
-from kai.reactive_codeplanner.task_runner.analyzer_lsp.api import AnalyzerRuleViolation
 
 LOG = get_logger(__name__)
 
@@ -234,31 +232,17 @@ class TaskBasedPathResolver(CachePathResolver):
 
     def _path_with_limit(self, root: Optional[Task], path: Path) -> Path:
         if len(str(path)) > self._limit and root is not None:
-            root_path = Path(root.__class__.__name__)
-            stem = Path(f"depth_{self.task.depth}") / self.task.__class__.__name__
-            if isinstance(root, ValidationError):
-                root_path /= self._clean_filename(root.file)
-            if isinstance(self.task, ValidationError):
-                if not isinstance(root, ValidationError) or (
-                    isinstance(root, ValidationError) and root.file != self.task.file
-                ):
-                    stem /= self._clean_filename(self.task.file)
-            if isinstance(self.task, AnalyzerRuleViolation):
-                stem /= self.task.violation.id
-            return root_path / stem / path.name
+            root_path = root.get_cache_path(Path("."))
+            task_path = self.task.get_cache_path(Path("."))
+            print(task_path)
+
+            return root_path.parent / task_path / path.name
         return path
 
     def _parent_file_path(self, task: Task) -> Optional[str]:
         if isinstance(task.parent, ValidationError):
             return task.parent.file
         return None
-
-    def _clean_filename(self, name: str) -> str:
-        filename = re.sub(r"[\\/:\.]", "_", name)
-        filename = re.sub(r"\_+", "_", filename)
-        segments = filename.split("_")
-        filename = "_".join(segments[-min(3, len(segments)) :])
-        return filename[-min(50, len(filename)) :]
 
     def _dfs(self, task: Optional[Task]) -> tuple[Optional[Task], Path]:
         """Recursively traverses the task all the way upto parent to generate unique cache file path
@@ -269,20 +253,9 @@ class TaskBasedPathResolver(CachePathResolver):
         root_node, root_path = self._dfs(task.parent)
         if root_node is None:
             root_node = task
-        if isinstance(task, ValidationError):
-            stem = Path(task.__class__.__name__)
-            # to minimize path, only add filepath to the root OR
-            # when its different than the immediate parent task
-            parent_file = self._parent_file_path(task)
-            if root_node == task or (
-                parent_file is not None and parent_file != task.file
-            ):
-                stem /= self._clean_filename(task.file)
-            if isinstance(task, AnalyzerRuleViolation):
-                stem /= task.violation.id
-        else:
-            stem = Path(task.__class__.__name__) / f"depth_{task.depth}"
-        return root_node, root_path / stem
+
+        root_path = task.get_cache_path(root_path)
+        return root_node, root_path
 
     def cache_meta(self) -> dict[str, str]:
         meta = {

--- a/kai/cache.py
+++ b/kai/cache.py
@@ -234,7 +234,6 @@ class TaskBasedPathResolver(CachePathResolver):
         if len(str(path)) > self._limit and root is not None:
             root_path = root.get_cache_path(Path("."))
             task_path = self.task.get_cache_path(Path("."))
-            print(task_path)
 
             return root_path.parent / task_path / path.name
         return path

--- a/kai/reactive_codeplanner/task_manager/api.py
+++ b/kai/reactive_codeplanner/task_manager/api.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -74,6 +75,20 @@ class Task:
         """Used by Agents to provide context when solving child issues"""
         raise NotImplementedError
 
+    def get_cache_path(self, root: Path) -> Path:
+        """Used by individual tasks to set the path"""
+        if self.depth == 0:
+            return root / self.__class__.__name__
+        stem = Path(f"depth_{self.depth}") / self.__class__.__name__
+        return root / stem
+
+    def _clean_filename(self, name: str) -> str:
+        filename = re.sub(r"[\\/:\.]", "_", name)
+        filename = re.sub(r"\_+", "_", filename)
+        segments = filename.split("_")
+        filename = "_".join(segments[-min(3, len(segments)) :])
+        return filename[-min(50, len(filename)) :]
+
     __repr__ = __str__
 
 
@@ -142,6 +157,11 @@ class ValidationError(Task):
         if self.parent is None:
             return ""
         return self.oldest_ancestor().background()
+
+    def get_cache_path(self, root: Path) -> Path:
+        root_path = super().get_cache_path(root)
+        root_path /= self._clean_filename(self.file)
+        return root_path
 
     __repr__ = __str__
 

--- a/kai/reactive_codeplanner/task_manager/api.py
+++ b/kai/reactive_codeplanner/task_manager/api.py
@@ -78,8 +78,12 @@ class Task:
     def get_cache_path(self, root: Path) -> Path:
         """Used by individual tasks to set the path"""
         if self.depth == 0:
-            return root / self.__class__.__name__
-        stem = Path(f"depth_{self.depth}") / self.__class__.__name__
+            stem = root / self.__class__.__name__
+        else:
+            stem = Path(f"depth_{self.depth}") / self.__class__.__name__
+
+        if self.retry_count > 0:
+            stem /= Path(self._clean_filename(f"retry_{self.retry_count}"))
         return root / stem
 
     def _clean_filename(self, name: str) -> str:

--- a/kai/reactive_codeplanner/task_runner/compiler/maven_validator.py
+++ b/kai/reactive_codeplanner/task_runner/compiler/maven_validator.py
@@ -213,6 +213,8 @@ class PackageDoesNotExistError(CollapsedMavenCompilerError):
             stem = Path(f"depth_{self.depth}") / self.__class__.__name__
         if self.missing_package:
             stem /= self._clean_filename(self.missing_package)
+        if self.retry_count > 0:
+            stem /= self._clean_filename(f"retry_{self.retry_count}")
         return root / stem
 
 

--- a/kai/reactive_codeplanner/task_runner/compiler/maven_validator.py
+++ b/kai/reactive_codeplanner/task_runner/compiler/maven_validator.py
@@ -182,6 +182,12 @@ class SymbolNotFoundError(CollapsedMavenCompilerError):
     def get_collapsable_key(self) -> str:
         return f"{self.file}-{self.__class__}-{self.missing_symbol}"
 
+    def get_cache_path(self, root: Path) -> Path:
+        root_path = super().get_cache_path(root)
+        if self.missing_symbol:
+            root_path /= self._clean_filename(self.missing_symbol)
+        return root_path
+
 
 @dataclass(eq=False)
 class PackageDoesNotExistError(CollapsedMavenCompilerError):
@@ -197,6 +203,17 @@ class PackageDoesNotExistError(CollapsedMavenCompilerError):
     # This does not have to be for file, because the package not existing is at the project level
     def get_collapsable_key(self) -> str:
         return f"{self.__class__}-{self.missing_package}"
+
+    def get_cache_path(self, root: Path) -> Path:
+        # Because we collapse these at package level, we can't use file from super
+        if self.depth == 0:
+            # We can't solve maven compiler errors yet so this shouldn't come up
+            stem = Path(self.__class__.__name__)
+        else:
+            stem = Path(f"depth_{self.depth}") / self.__class__.__name__
+        if self.missing_package:
+            stem /= self._clean_filename(self.missing_package)
+        return root / stem
 
 
 @dataclass(eq=False)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -49,6 +49,7 @@ class TestCache(unittest.TestCase):
             depth=1,
             column=2,
             message="package not found",
+            missing_package="jakarta.sql",
             parent=self.t1,
         )
         self.t3 = DependencyResolutionError(
@@ -65,6 +66,7 @@ class TestCache(unittest.TestCase):
             depth=3,
             column=2,
             message="cannot find symbol",
+            missing_symbol="javax.inject.Inject",
             parent=self.t3,
         )
 
@@ -78,17 +80,21 @@ class TestCache(unittest.TestCase):
             "AnalyzerRuleViolation",
             "konveyor_main_java",
             "rule-id-000",
+            "depth_1",
             "PackageDoesNotExistError",
-            "test_pom_xml",
+            "jakarta_sql",
             "0_analyzerfix.json",
         )
         self.t3_cache_expected_path = Path(
             "AnalyzerRuleViolation",
             "konveyor_main_java",
             "rule-id-000",
+            "depth_1",
             "PackageDoesNotExistError",
-            "test_pom_xml",
+            "jakarta_sql",
+            "depth_2",
             "DependencyResolutionError",
+            "test_pom_xml",
             "0_analyzerfix.json",
         )
         self.t4_cache_expected_path = Path(
@@ -96,6 +102,8 @@ class TestCache(unittest.TestCase):
             "konveyor_main_java",
             "depth_3",
             "SymbolNotFoundError",
+            "konveyor_main_java",
+            "javax_inject_Inject",
             "0_analyzerfix.json",
         )
 
@@ -122,8 +130,9 @@ class TestCache(unittest.TestCase):
             t2_cache_path,
             t1_cache_path.parent
             / Path(
+                "depth_1",
                 "PackageDoesNotExistError",
-                "test_pom_xml",
+                "jakarta_sql",
                 "0_analyzerfix.json",
             ),
         )
@@ -136,7 +145,9 @@ class TestCache(unittest.TestCase):
             t3_cache_path,
             t2_cache_path.parent
             / Path(
+                "depth_2",
                 "DependencyResolutionError",
+                "test_pom_xml",
                 "0_analyzerfix.json",
             ),
         )


### PR DESCRIPTION
* This makes it easier to determine what the path should be for each task, as tasks have more and more divergent data
* Removes the cache overwrite for SymbolNotFound and PackageDoesNotExistErrors
* Adds the depth to file tree to see effort level at work.
* In the future we should consider enhancing this, so that tasks can add data to the trace to make debugging even easier