### PR TITLE
:bug: Fixing up the symbol not found and dependency agents 

### DIFF
--- a/.trunk/configs/custom-words.txt
+++ b/.trunk/configs/custom-words.txt
@@ -148,3 +148,7 @@ venv
 webassets
 webmvc
 SHFT
+httpsnoop
+felixge
+cenkalti
+tmpl

--- a/kai/cache.py
+++ b/kai/cache.py
@@ -234,7 +234,6 @@ class TaskBasedPathResolver(CachePathResolver):
         if len(str(path)) > self._limit and root is not None:
             root_path = root.get_cache_path(Path("."))
             task_path = self.task.get_cache_path(Path("."))
-
             return root_path.parent / task_path / path.name
         return path
 

--- a/kai/reactive_codeplanner/agent/maven_compiler_fix/agent.py
+++ b/kai/reactive_codeplanner/agent/maven_compiler_fix/agent.py
@@ -21,8 +21,6 @@ class MavenCompilerAgent(Agent):
         """{{ background }}
     I will give you compiler errors and the offending line of code, and you will need to use the file to determine how to fix them. You should only use compiler errors to determine what to fix.
 
-    Make sure that the references to any changed types are kept.
-
     You must reason through the required changes and rewrite the Java file to make it compile. 
 
     You will then provide an step-by-step explanation of the changes required so that someone could recreate it in a similar situation.

--- a/kai/reactive_codeplanner/task_runner/compiler/compiler_task_runner.py
+++ b/kai/reactive_codeplanner/task_runner/compiler/compiler_task_runner.py
@@ -18,6 +18,7 @@ from kai.reactive_codeplanner.task_runner.compiler.maven_validator import (
     DependencyResolutionError,
     MavenCompilerError,
     OtherError,
+    SymbolNotFoundError,
     SyntaxError,
     TypeMismatchError,
 )
@@ -52,6 +53,7 @@ class MavenCompilerTaskRunner(TaskRunner):
         AccessControlError,
         OtherError,
         DependencyResolutionError,
+        SymbolNotFoundError,
     )
 
     def __init__(self, agent: MavenCompilerAgent) -> None:

--- a/kai/reactive_codeplanner/task_runner/dependency/api.py
+++ b/kai/reactive_codeplanner/task_runner/dependency/api.py
@@ -1,8 +1,0 @@
-from dataclasses import dataclass
-
-from kai.reactive_codeplanner.task_manager.api import ValidationError
-
-
-@dataclass
-class DependencyValidationError(ValidationError):
-    pass


### PR DESCRIPTION
* Make it so that the FQDN agent doesn't cause LLM to cycle on itself
* Make it so the FQDN agent has a system prompt, that will help with
  context window issues
* Make it so that the SymbolNotFound issues go to the maven compiler.
  This is because if the dependency is missing from the project both a
symbol not found and a package does not exist are created. If just a
symbol not found, then the issue is the Class changed.


This is built on #653 to make debugging easier. 

After this change, with openshift-ai, I can fix the DatabaseMigrationStartup.java file in around 6 minutes, where before it was taking upwards of 20-30. 

fixes #650 