### PR TITLE
:bug: Adding back the reset of the repository before we send the response back

### DIFF
--- a/kai/rpc_server/server.py
+++ b/kai/rpc_server/server.py
@@ -635,6 +635,7 @@ def get_codeplan_agent_solution(
         overall_result.diff = diff[1] + diff[2]
 
         chatter.get().chat_simple("Finished!")
+        app.rcm.reset(agent_solution_snapshot)
 
         server.send_response(
             id=id,


### PR DESCRIPTION
* This was causing bugs on the front end, where the files being read from disk, were not the reset versions, and therefore the patches were failing.

* The internals of the reset, should still allow for multiple calls, this should not hurt anything and we still get the benifit of resetting on exception.

fixes #668 