### PR TITLE
:sparkles: Added continuation support for Amazon Bedrock

### DIFF
--- a/.trunk/configs/custom-words.txt
+++ b/.trunk/configs/custom-words.txt
@@ -150,15 +150,9 @@ tgis
 tiiuae
 tmpl
 tracesdk
+uberjar
 upperbound
 venv
 VLLM
 webassets
 webmvc
-SHFT
-httpsnoop
-felixge
-cenkalti
-tmpl
-sdktrace
-uberjar

--- a/.trunk/configs/custom-words.txt
+++ b/.trunk/configs/custom-words.txt
@@ -38,6 +38,7 @@ flywaydb
 frobinate
 genai
 genproto
+getpid
 gomod
 gopls
 gpgsign
@@ -118,14 +119,16 @@ PYTHONPATH
 pytype
 quarkus
 resteasy
+rhoai
 ropeproject
 Scrapy
 sdist
+sdktrace
 semconv
 sessionbean
+SHFT
 shurley
 sirupsen
-rhoai
 smallrye
 springboot
 springframework
@@ -145,9 +148,11 @@ testnested
 textmap
 tgis
 tiiuae
+tmpl
 tracesdk
 upperbound
 venv
+VLLM
 webassets
 webmvc
 SHFT

--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -358,8 +358,10 @@ class ModelProviderChatBedrock(ModelProvider):
 
         response = invoke_llm.invoke(messages, config, stop=stop, **kwargs)
         # TODO: Figure out if message.content is ever anything but a string
-        response.content = str(response.content).strip()
+        response.content = response.text().strip()
 
+        # Bedrock stop sequences:
+        # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_MessageStopEvent.html
         while (
             response.response_metadata.get("stop_reason") == "max_tokens"
             or response.additional_kwargs.get("stop_reason") == "max_tokens"
@@ -369,9 +371,7 @@ class ModelProviderChatBedrock(ModelProvider):
             new_response = invoke_llm.invoke(
                 messages + [response], config, stop=stop, **kwargs
             )
-            new_response.content = (
-                response.content + str(new_response.content)
-            ).strip()
+            new_response.content = (response.text() + new_response.text()).strip()
 
             response = new_response
 

--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -351,10 +351,10 @@ class ModelProviderChatBedrock(ModelProvider):
             if continuation:
                 # TODO: Figure out if message.content is ever anything but a string
                 messages[-1] = AIMessage(
-                    str(messages[-1].content) + str(message.content)
+                    (str(messages[-1].content) + str(message.content)).strip()
                 )
             else:
-                messages.append(AIMessage(message.content))
+                messages.append(AIMessage(str(message.content).strip()))
                 continuation = True
 
             if message.response_metadata.get("stop_reason") != "max_tokens":

--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Optional
+from abc import abstractmethod
+from typing import Any, Iterator, Optional, Sequence, assert_never, cast
 
 from langchain_aws import ChatBedrock
 from langchain_community.chat_models.fake import FakeListChatModel
 from langchain_core.language_models.base import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    BaseMessageChunk,
+    HumanMessage,
+)
+from langchain_core.prompt_values import PromptValue
 from langchain_core.runnables import ConfigurableField, RunnableConfig
 from langchain_deepseek import ChatDeepSeek
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -17,7 +24,7 @@ from opentelemetry import trace
 from pydantic.v1.utils import deep_update
 
 from kai.cache import Cache, CachePathResolver, SimplePathResolver
-from kai.kai_config import KaiConfigModels
+from kai.kai_config import KaiConfigModels, SupportedModelProviders
 from kai.logging.logging import get_logger
 
 LOG = get_logger(__name__)
@@ -25,193 +32,128 @@ tracer = trace.get_tracer("model_provider")
 
 
 class ModelProvider:
+    @staticmethod
+    def from_config(
+        config: KaiConfigModels,
+        demo_mode: bool = False,
+        cache: Cache | None = None,
+    ) -> "ModelProvider":
+        match config.provider:
+            case SupportedModelProviders.CHAT_OLLAMA:
+                return ModelProviderChatOllama(config, demo_mode, cache)
+            case SupportedModelProviders.CHAT_OPENAI:
+                return ModelProviderChatOpenAI(config, demo_mode, cache)
+            case SupportedModelProviders.CHAT_BEDROCK:
+                return ModelProviderChatBedrock(config, demo_mode, cache)
+            case SupportedModelProviders.FAKE_LIST_CHAT_MODEL:
+                return ModelProviderFakeListChatModel(config, demo_mode, cache)
+            case SupportedModelProviders.CHAT_GOOGLE_GENERATIVE_AI:
+                return ModelProviderChatGoogleGenerativeAI(config, demo_mode, cache)
+            case SupportedModelProviders.AZURE_CHAT_OPENAI:
+                return ModelProviderAzureChatOpenAI(config, demo_mode, cache)
+            case SupportedModelProviders.CHAT_DEEP_SEEK:
+                return ModelProviderChatDeepSeek(config, demo_mode, cache)
+            case _:
+                assert_never(config.provider)
+
     def __init__(
         self,
         config: KaiConfigModels,
-        demo_mode: bool = False,
-        cache: Optional[Cache] = None,
-    ):
-        self.llm_retries: int = config.llm_retries
-        self.llm_retry_delay: float = config.llm_retry_delay
-        self.demo_mode: bool = demo_mode
-        self.cache = cache
-
-        model_class: type[BaseChatModel]
-        defaults: dict[str, Any]
-        model_args: dict[str, Any]
-        model_id: str
-
-        # Set the model class, model args, and model id based on the provider
-        match config.provider:
-            case "ChatOllama":
-                model_class = ChatOllama
-
-                defaults = {
-                    "model": "mistral",
-                    "temperature": 0.1,
-                    "max_tokens": None,
-                    "streaming": True,
-                }
-
-                model_args = deep_update(defaults, config.args)
-                model_id = model_args["model"]
-
-            case "ChatOpenAI":
-                model_class = ChatOpenAI
-
-                defaults = {
-                    "model": "gpt-3.5-turbo",
-                    "temperature": 0.1,
-                    "streaming": True,
-                }
-
-                model_args = deep_update(defaults, config.args)
-                model_id = model_args["model"]
-
-                # NOTE(JonahSussman): This is a hack to prevent `max_tokens`
-                # from getting converted to `max_completion_tokens` for every
-                # model, except for the o1 and o3 family of models.
-
-                @property  # type: ignore[misc]
-                def _default_params(self: ChatOpenAI) -> dict[str, Any]:
-                    return super(ChatOpenAI, self)._default_params
-
-                def _get_request_payload(
-                    self: ChatOpenAI,
-                    input_: LanguageModelInput,
-                    *,
-                    stop: list[str] | None = None,
-                    **kwargs: Any,
-                ) -> dict:  # type: ignore[type-arg]
-                    return super(ChatOpenAI, self)._get_request_payload(
-                        input_, stop=stop, **kwargs
-                    )
-
-                if not (model_id.startswith("o1") or model_id.startswith("o3")):
-                    ChatOpenAI._default_params = _default_params  # type: ignore[method-assign]
-                    ChatOpenAI._get_request_payload = _get_request_payload  # type: ignore[method-assign]
-                else:
-                    if "streaming" in model_args:
-                        del model_args["streaming"]
-                    if "temperature" in model_args:
-                        del model_args["temperature"]
-
-            case "ChatBedrock":
-                model_class = ChatBedrock
-
-                defaults = {
-                    "model_id": "meta.llama3-70b-instruct-v1:0",
-                }
-
-                model_args = deep_update(defaults, config.args)
-                model_id = model_args["model_id"]
-
-            case "FakeListChatModel":
-                model_class = FakeListChatModel
-
-                defaults = {
-                    "responses": [
-                        "## Reasoning\n"
-                        "\n"
-                        "Default reasoning.\n"
-                        "\n"
-                        "## Updated File\n"
-                        "\n"
-                        "```\n"
-                        "Default updated file.\n"
-                        "```\n"
-                        "\n"
-                        "## Additional Information\n"
-                        "\n"
-                        "Default additional information.\n"
-                        "\n"
-                    ],
-                    "sleep": None,
-                }
-
-                model_args = deep_update(defaults, config.args)
-                model_id = "fake-list-chat-model"
-
-            case "ChatGoogleGenerativeAI":
-                model_class = ChatGoogleGenerativeAI
-                api_key = os.getenv("GOOGLE_API_KEY", "dummy_value")
-                defaults = {
-                    "model": "gemini-pro",
-                    "temperature": 0.7,
-                    "streaming": False,
-                    "google_api_key": api_key,
-                }
-                model_args = deep_update(defaults, config.args)
-                model_id = model_args["model"]
-
-            case "AzureChatOpenAI":
-                model_class = AzureChatOpenAI
-
-                defaults = {
-                    "azure_deployment": "gpt-35-turbo",
-                    "api_version": "2023-06-01-preview",
-                    "temperature": 0.1,
-                    "max_tokens": None,
-                    "timeout": None,
-                    "max_retries": 2,
-                }
-
-                model_args = deep_update(defaults, config.args)
-                model_id = model_args["azure_deployment"]
-
-            case "ChatDeepSeek":
-                model_class = ChatDeepSeek
-
-                defaults = {
-                    "model": "deepseek-chat",
-                    "temperature": 0,
-                    "max_tokens": None,
-                    "timeout": None,
-                    "max_retries": 2,
-                }
-
-                model_args = deep_update(defaults, config.args)
-                model_id = model_args["model"]
-
-            case _:
-                raise Exception(f"Unrecognized provider '{config.provider}'")
-
-        self.provider_id: str = config.provider
-        self.llm: BaseChatModel = model_class(**model_args)
-        self.model_id: str = model_id
-
-        if config.template is None:
-            self.template = self.model_id
-        else:
-            self.template = config.template
-
-    def validate_environment(
-        self,
+        demo_mode: bool,
+        cache: Cache | None,
+        model_class: type[BaseChatModel],
+        defaults: dict[str, Any],
     ) -> None:
+        self.llm_retries = config.llm_retries
+        self.llm_retry_delay = config.llm_retry_delay
+        self.demo_mode = demo_mode
+        self.cache = cache
+        self.provider_id = config.provider
+        self.model_class = model_class
+        self.validate_environment_resolver = SimplePathResolver(
+            "validate_environment.json"
+        )
+
+        self.model_args, self.model_id = self.prepare_model_args(defaults, config.args)
+        self.llm: BaseChatModel = self.model_class(**self.model_args)
+
+    @abstractmethod
+    def prepare_model_args(
+        self, defaults: dict[str, Any], config_args: dict[str, Any]
+    ) -> tuple[dict[str, Any], str]:
+        """
+        Do any necessary clever cleanup of the model args. Returns the model args and
+        the model id.
+        """
+        ...
+
+        # I'd like to do something like the following, but it didn't work when I tried it:
+
+        # for attr in ["model", "model_name", "model_id", "azure_deployment"]:
+        #     if hasattr(self.model_class, attr):
+        #         return deep_update(defaults, config_args), config_args[attr]
+
+        # raise Exception(f"Could not get model id for {self.model_class}. {dir(self.model_class)=}")
+
+    def default_challenge(self, k: str) -> BaseMessage:
+        return self.invoke(
+            "a", self.validate_environment_resolver, configurable_fields={k: 1}
+        )
+
+    @abstractmethod
+    def validate_environment(self) -> None:
         """
         Raises an exception if the environment is not set up correctly for the
         current model provider.
         """
+        ...
 
-        cpr = SimplePathResolver("validate_environment.json")
+    def configurable_llm(
+        self,
+        configurable_fields: dict[str, Any] | None = None,
+    ) -> BaseChatModel:
+        """
+        Some fields can only be configured when the model is instantiated. This
+        side-steps that by creating a new instance of the model with the configurable
+        fields set, then invoking that new instance.
+        """
+        if configurable_fields is not None:
+            result = self.llm.configurable_fields(
+                **{k: ConfigurableField(id=k) for k in configurable_fields}
+            ).with_config(
+                configurable_fields  # type: ignore[arg-type]
+            )
+            return cast(BaseChatModel, result)  # TODO: Check if this cast is ok
+        else:
+            return self.llm
 
-        def challenge(k: str) -> BaseMessage:
-            return self.invoke("a", cpr, configurable_fields={k: 1})
+    def invoke_llm(
+        self,
+        input: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        configurable_fields: dict[str, Any] | None = None,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> BaseMessage:
+        """
+        Method to invoke the actual LLM. This can be overridden by subclasses to
+        provide additional functionality.
+        """
+        return self.configurable_llm(configurable_fields).invoke(
+            input, config, stop=stop, **kwargs
+        )
 
-        if isinstance(self.llm, ChatOllama):
-            challenge("num_predict")
-        elif isinstance(self.llm, ChatOpenAI):
-            challenge("max_tokens")
-        elif isinstance(self.llm, ChatBedrock):
-            challenge("max_tokens")
-        elif isinstance(self.llm, FakeListChatModel):
-            pass
-        elif isinstance(self.llm, ChatGoogleGenerativeAI):
-            challenge("max_output_tokens")
-        elif isinstance(self.llm, AzureChatOpenAI):
-            challenge("max_tokens")
-        elif isinstance(self.llm, ChatDeepSeek):
-            challenge("max_tokens")
+    def stream_llm(
+        self,
+        input: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        configurable_fields: dict[str, Any] | None = None,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> Iterator[BaseMessageChunk]:
+        return self.configurable_llm(configurable_fields).stream(
+            input, config, stop=stop, **kwargs
+        )
 
     @tracer.start_as_current_span("invoke_llm")
     def invoke(
@@ -224,22 +166,14 @@ class ModelProvider:
         stop: Optional[list[str]] = None,
         **kwargs: Any,
     ) -> BaseMessage:
+        """
+        Method that invokes the LLM and caches the result if necessary.
+        """
         span = trace.get_current_span()
         span.set_attribute("model", self.model_id)
-        # Some fields can only be configured when the model is instantiated.
-        # This side-steps that by creating a new instance of the model with the
-        # configurable fields set, then invoking that new instance.
-        if configurable_fields is not None:
-            invoke_llm = self.llm.configurable_fields(
-                **{k: ConfigurableField(id=k) for k in configurable_fields}
-            ).with_config(
-                configurable_fields  # type: ignore[arg-type]
-            )
-        else:
-            invoke_llm = self.llm
 
         if not (self.cache and cache_path_resolver):
-            return invoke_llm.invoke(input, config, stop=stop, **kwargs)
+            return self.invoke_llm(input, config, stop=stop, **kwargs)
 
         cache_path = cache_path_resolver.cache_path()
         cache_meta = cache_path_resolver.cache_meta()
@@ -250,7 +184,7 @@ class ModelProvider:
             if cache_entry:
                 return cache_entry
 
-        response = invoke_llm.invoke(input, config, stop=stop, **kwargs)
+        response = self.invoke_llm(input, config, stop=stop, **kwargs)
 
         try:
             self.cache.put(
@@ -264,3 +198,288 @@ class ModelProvider:
             if self.demo_mode:
                 raise e
         return response
+
+    @tracer.start_as_current_span("stream_llm")
+    def stream(
+        self,
+        input: LanguageModelInput,
+        cache_path_resolver: Optional[CachePathResolver] = None,
+        config: Optional[RunnableConfig] = None,
+        *,
+        configurable_fields: Optional[dict[str, Any]] = None,
+        stop: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> Iterator[BaseMessageChunk]:
+        """
+        Method that streams the LLM and caches the result if necessary.
+        """
+        # FIXME: Not caching the stream results currently
+        yield from self.stream_llm(input, config, stop=stop, **kwargs)
+
+
+class ModelProviderChatOllama(ModelProvider):
+    def __init__(self, config: KaiConfigModels, demo_mode: bool, cache: Cache | None):
+        super().__init__(
+            config=config,
+            demo_mode=demo_mode,
+            cache=cache,
+            model_class=ChatOllama,
+            defaults={
+                "model": "mistral",
+                "temperature": 0.1,
+                "max_tokens": None,
+                "streaming": True,
+            },
+        )
+
+    def validate_environment(self) -> None:
+        self.default_challenge("num_predict")
+
+    def prepare_model_args(
+        self,
+        defaults: dict[str, Any],
+        config_args: dict[str, Any],
+    ) -> tuple[dict[str, Any], str]:
+        return deep_update(defaults, config_args), config_args["model"]
+
+
+class ModelProviderChatOpenAI(ModelProvider):
+    def __init__(self, config: KaiConfigModels, demo_mode: bool, cache: Cache | None):
+        super().__init__(
+            config=config,
+            demo_mode=demo_mode,
+            cache=cache,
+            model_class=ChatOpenAI,
+            defaults={
+                "model": "gpt-3.5-turbo",
+                "temperature": 0.1,
+                "streaming": True,
+            },
+        )
+
+    def validate_environment(self) -> None:
+        self.default_challenge("max_tokens")
+
+    def prepare_model_args(
+        self,
+        defaults: dict[str, Any],
+        config_args: dict[str, Any],
+    ) -> tuple[dict[str, Any], str]:
+        model_args = deep_update(defaults, config_args)
+        model_id = model_args["model"]
+
+        # NOTE(JonahSussman): This is a hack to prevent `max_tokens`
+        # from getting converted to `max_completion_tokens` for every
+        # model, except for the o1 and o3 family of models.
+
+        @property  # type: ignore[misc]
+        def _default_params(self: ChatOpenAI) -> dict[str, Any]:
+            return super(ChatOpenAI, self)._default_params
+
+        def _get_request_payload(
+            self: ChatOpenAI,
+            input_: LanguageModelInput,
+            *,
+            stop: list[str] | None = None,
+            **kwargs: Any,
+        ) -> dict:  # type: ignore[type-arg]
+            return super(ChatOpenAI, self)._get_request_payload(
+                input_, stop=stop, **kwargs
+            )
+
+        if not (
+            model_args["model"].startswith("o1") or model_args["model"].startswith("o3")
+        ):
+            ChatOpenAI._default_params = _default_params  # type: ignore[method-assign]
+            ChatOpenAI._get_request_payload = _get_request_payload  # type: ignore[method-assign]
+        else:
+            if "streaming" in model_args:
+                del model_args["streaming"]
+            if "temperature" in model_args:
+                del model_args["temperature"]
+
+        return model_args, model_id
+
+
+class ModelProviderChatBedrock(ModelProvider):
+    def __init__(self, config: KaiConfigModels, demo_mode: bool, cache: Cache | None):
+        super().__init__(
+            config=config,
+            demo_mode=demo_mode,
+            cache=cache,
+            model_class=ChatBedrock,
+            defaults={
+                "model_id": "meta.llama3-70b-instruct-v1:0",
+            },
+        )
+
+    def validate_environment(self) -> None:
+        self.default_challenge("max_tokens")
+
+    def prepare_model_args(
+        self,
+        defaults: dict[str, Any],
+        config_args: dict[str, Any],
+    ) -> tuple[dict[str, Any], str]:
+        return deep_update(defaults, config_args), config_args["model_id"]
+
+    def invoke_llm(
+        self,
+        input: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        configurable_fields: dict[str, Any] | None = None,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> BaseMessage:
+        invoke_llm = self.configurable_llm(configurable_fields)
+
+        messages: list[BaseMessage] = []
+        continuation = False
+
+        if isinstance(input, str):
+            messages = [HumanMessage(input)]
+        elif isinstance(input, PromptValue):
+            messages = [HumanMessage(input.to_string())]
+        elif isinstance(input, Sequence):
+            messages = list(input)  # type: ignore[arg-type]
+        else:
+            assert_never(input)
+
+        while True:
+            message = invoke_llm.invoke(messages, config, stop=stop, **kwargs)
+
+            if continuation:
+                # TODO: Figure out if message.content is ever anything but a string
+                messages[-1] = AIMessage(
+                    str(messages[-1].content) + str(message.content)
+                )
+            else:
+                messages.append(AIMessage(message.content))
+                continuation = True
+
+            if message.response_metadata.get("stop_reason") != "max_tokens":
+                break
+
+            LOG.info("Message did not fit in max tokens. Continuing...")
+
+        return messages[-1]
+
+
+class ModelProviderFakeListChatModel(ModelProvider):
+    def __init__(self, config: KaiConfigModels, demo_mode: bool, cache: Cache | None):
+        super().__init__(
+            config=config,
+            demo_mode=demo_mode,
+            cache=cache,
+            model_class=FakeListChatModel,
+            defaults={
+                "responses": [
+                    "## Reasoning\n"
+                    "\n"
+                    "Default reasoning.\n"
+                    "\n"
+                    "## Updated File\n"
+                    "\n"
+                    "```\n"
+                    "Default updated file.\n"
+                    "```\n"
+                    "\n"
+                    "## Additional Information\n"
+                    "\n"
+                    "Default additional information.\n"
+                    "\n"
+                ],
+                "sleep": None,
+            },
+        )
+
+    def validate_environment(self) -> None:
+        return
+
+    def prepare_model_args(
+        self,
+        defaults: dict[str, Any],
+        config_args: dict[str, Any],
+    ) -> tuple[dict[str, Any], str]:
+        return deep_update(defaults, config_args), "fake-list-chat-model"
+
+
+class ModelProviderChatGoogleGenerativeAI(ModelProvider):
+    def __init__(self, config: KaiConfigModels, demo_mode: bool, cache: Cache | None):
+        super().__init__(
+            config=config,
+            demo_mode=demo_mode,
+            cache=cache,
+            model_class=ChatGoogleGenerativeAI,
+            defaults={
+                "model": "gemini-pro",
+                "temperature": 0.7,
+                "streaming": False,
+                "google_api_key": os.getenv("GOOGLE_API_KEY", "dummy_value"),
+            },
+        )
+
+    def validate_environment(self) -> None:
+        self.default_challenge("max_output_tokens")
+
+    def prepare_model_args(
+        self,
+        defaults: dict[str, Any],
+        config_args: dict[str, Any],
+    ) -> tuple[dict[str, Any], str]:
+        return deep_update(defaults, config_args), config_args["model"]
+
+
+class ModelProviderAzureChatOpenAI(ModelProvider):
+    def __init__(self, config: KaiConfigModels, demo_mode: bool, cache: Cache | None):
+        super().__init__(
+            config=config,
+            demo_mode=demo_mode,
+            cache=cache,
+            model_class=AzureChatOpenAI,
+            defaults={
+                "azure_deployment": "gpt-35-turbo",
+                "api_version": "2023-06-01-preview",
+                "temperature": 0.1,
+                "max_tokens": None,
+                "timeout": None,
+                "max_retries": 2,
+            },
+        )
+
+    def validate_environment(self) -> None:
+        self.default_challenge("max_tokens")
+
+    def prepare_model_args(
+        self,
+        defaults: dict[str, Any],
+        config_args: dict[str, Any],
+    ) -> tuple[dict[str, Any], str]:
+        return deep_update(defaults, config_args), config_args["azure_deployment"]
+
+
+class ModelProviderChatDeepSeek(ModelProvider):
+    def __init__(self, config: KaiConfigModels, demo_mode: bool, cache: Cache | None):
+        super().__init__(
+            config=config,
+            demo_mode=demo_mode,
+            cache=cache,
+            model_class=ChatDeepSeek,
+            defaults={
+                "model": "deepseek-chat",
+                "temperature": 0,
+                "max_tokens": None,
+                "timeout": None,
+                "max_retries": 2,
+            },
+        )
+
+    def validate_environment(self) -> None:
+        self.default_challenge("max_tokens")
+
+    def prepare_model_args(
+        self,
+        defaults: dict[str, Any],
+        config_args: dict[str, Any],
+    ) -> tuple[dict[str, Any], str]:
+        return deep_update(defaults, config_args), config_args["model"]

--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -173,7 +173,7 @@ class ModelProvider:
         span.set_attribute("model", self.model_id)
 
         if not (self.cache and cache_path_resolver):
-            return self.invoke_llm(input, config, stop=stop, **kwargs)
+            return self.invoke_llm(input, config, configurable_fields, stop, **kwargs)
 
         cache_path = cache_path_resolver.cache_path()
         cache_meta = cache_path_resolver.cache_meta()
@@ -184,7 +184,7 @@ class ModelProvider:
             if cache_entry:
                 return cache_entry
 
-        response = self.invoke_llm(input, config, stop=stop, **kwargs)
+        response = self.invoke_llm(input, config, configurable_fields, stop, **kwargs)
 
         try:
             self.cache.put(

--- a/kai/llm_interfacing/model_provider.py
+++ b/kai/llm_interfacing/model_provider.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import time
 from abc import abstractmethod
 from typing import Any, Iterator, Optional, Sequence, assert_never, cast, override
 
@@ -364,10 +363,7 @@ class ModelProviderChatBedrock(ModelProvider):
             assert_never(input)
 
         while True:
-            LOG.info(f"Invoking LLM with messages: {messages}")
             message = invoke_llm.invoke(messages, config, stop=stop, **kwargs)
-            LOG.info(f"Got message: {message}")
-            time.sleep(1)
 
             if continuation:
                 # TODO: Figure out if message.content is ever anything but a string

--- a/kai/reactive_codeplanner/agent/analyzer_fix/agent.py
+++ b/kai/reactive_codeplanner/agent/analyzer_fix/agent.py
@@ -30,10 +30,9 @@ class _llm_response:
 
 class AnalyzerAgent(Agent):
     system_message_template = Template(
-        """
-    You are an experienced {{ language }} developer, who specializes in migrating code from {{ source }} to {{ target }}
-    {{ background }}
-    """
+        """You are an experienced {{ language }} developer, who specializes in migrating code from {{ source }} to {{ target }}
+{{ background }}
+"""
     )
 
     chat_message_template = Template(
@@ -90,7 +89,7 @@ Write the step by step reasoning in this markdown section. If you are unsure of 
 
 If you have any additional details or steps that need to be performed, put it here.
 
-    """
+"""
     )
 
     def __init__(

--- a/kai/reactive_codeplanner/main.py
+++ b/kai/reactive_codeplanner/main.py
@@ -142,7 +142,7 @@ def main() -> None:
 
     logging.init_logging_from_log_config(kai_config.log_config)
 
-    model_provider = ModelProvider(kai_config.model_provider)
+    model_provider = ModelProvider.from_config(kai_config.model_provider)
 
     analyzer = AnalyzerLSP(
         analyzer_lsp_server_binary=Path(args.analyzer_lsp_server_binary),

--- a/kai/reactive_codeplanner/task_manager/task_manager.py
+++ b/kai/reactive_codeplanner/task_manager/task_manager.py
@@ -247,7 +247,7 @@ class TaskManager:
         logger.info(
             "Handling depth 0 task, assuming fix has applied for task: %s", task
         )
-        chatter.get().chat_simple(f"completed task: {task}")
+        chatter.get().chat_simple(f"Completed task {task}.")
         self.priority_queue.remove(task)
 
     def handle_new_tasks_after_processing(

--- a/kai/rpc_server/server.py
+++ b/kai/rpc_server/server.py
@@ -189,7 +189,7 @@ def initialize(
                 trace_dir=app.config.log_config.log_dir_path / "traces",
                 fail_on_cache_mismatch=app.config.fail_on_cache_mismatch,
             )
-            model_provider = ModelProvider(
+            model_provider = ModelProvider.from_config(
                 app.config.model_provider, app.config.demo_mode, cache
             )
             cache.model_id = re.sub(r"[\.:\\/]", "_", model_provider.model_id)

--- a/kai_solution_server/service/incident_store/incident_store.py
+++ b/kai_solution_server/service/incident_store/incident_store.py
@@ -523,7 +523,7 @@ class IncidentStore:
 
     @staticmethod
     def incident_store_from_config(config: KaiSolutionServerConfig) -> "IncidentStore":
-        model_provider = ModelProvider(config.models)
+        model_provider = ModelProvider.from_config(config.models)
 
         KAI_LOG.info(f"Selected provider: {config.models.provider}")
         KAI_LOG.info(f"Selected model: {model_provider.model_id}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "pygments==2.18.0",
   "python-dateutil==2.8.2",
   "Jinja2==3.1.4",
-  "langchain==0.3.17",
+  "langchain==0.3.19",
   "langchain-community==0.3.1",
   "langchain-openai==0.3.3",
   "langchain-ollama==0.2.3",

--- a/tests/test_analyzer_agent.py
+++ b/tests/test_analyzer_agent.py
@@ -23,7 +23,7 @@ from kai.reactive_codeplanner.task_manager.api import ValidationError
 class TestAnalyzerAgent(unittest.TestCase):
 
     def test_parse_llm_response_one_thought(self) -> None:
-        model_provider = ModelProvider(
+        model_provider = ModelProvider.from_config(
             KaiConfigModels(
                 provider="FakeListChatModel",
                 args={
@@ -60,7 +60,7 @@ class TestAnalyzerAgent(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_invalid_request_type(self) -> None:
-        model_provider = ModelProvider(
+        model_provider = ModelProvider.from_config(
             KaiConfigModels(
                 provider="FakeListChatModel",
                 args={
@@ -116,7 +116,7 @@ public class ShoppingCartService  {
   </dependency>
   ```
 """
-        model_provider = ModelProvider(
+        model_provider = ModelProvider.from_config(
             KaiConfigModels(
                 provider="FakeListChatModel",
                 args={

--- a/tests/test_dependency_task_runner.py
+++ b/tests/test_dependency_task_runner.py
@@ -67,7 +67,7 @@ Final Answer: Added the MicroProfile Reactive Messaging dependency with groupId 
         ]
         return DependencyTaskRunner(
             MavenDependencyAgent(
-                model_provider=ModelProvider(
+                model_provider=ModelProvider.from_config(
                     config=KaiConfigModels(
                         args={
                             "responses": responses[response_variant],

--- a/tests/test_incident_store.py
+++ b/tests/test_incident_store.py
@@ -115,7 +115,7 @@ class FakeLLMIncidentStore(Fixture):
         backend = incident_store_backend_factory(args)
         solution_detector = solution_detection_naive
         solution_producer = SolutionProducerLLMLazy(
-            ModelProvider(
+            ModelProvider.from_config(
                 KaiConfigModels(
                     provider="FakeListChatModel",
                     args={

--- a/tests/test_maven_compiler_agent.py
+++ b/tests/test_maven_compiler_agent.py
@@ -20,7 +20,7 @@ from kai.reactive_codeplanner.task_runner.compiler.maven_validator import (
 class TestMavenCompilerAgent(unittest.TestCase):
 
     def test_parse_llm_response_one_thought(self):
-        model_provider = ModelProvider(
+        model_provider = ModelProvider.from_config(
             KaiConfigModels(
                 provider="FakeListChatModel",
                 args={
@@ -55,7 +55,7 @@ class TestMavenCompilerAgent(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_invalid_request_type(self):
-        model_provider = ModelProvider(
+        model_provider = ModelProvider.from_config(
             KaiConfigModels(
                 provider="FakeListChatModel",
                 args={

--- a/tests/test_model_provider.py
+++ b/tests/test_model_provider.py
@@ -27,7 +27,7 @@ class TestModelProvider(unittest.TestCase):
             },
         )
 
-        model_provider = ModelProvider(config)
+        model_provider = ModelProvider.from_config(config)
 
         for x in responses:
             result = model_provider.llm.invoke("test").content
@@ -41,7 +41,7 @@ class TestModelProvider(unittest.TestCase):
                 args={},
             )
 
-            model = ModelProvider(config)
+            model = ModelProvider.from_config(config)
             model.validate_environment()
 
             return model

--- a/tests/test_reflection_agent.py
+++ b/tests/test_reflection_agent.py
@@ -16,7 +16,9 @@ class TestReflectionAgent(unittest.TestCase):
         super().setUp()
 
         self.reflection_agent: ReflectionAgent = ReflectionAgent(
-            model_provider=ModelProvider(KaiConfigModels(provider="FakeListChatModel"))
+            model_provider=ModelProvider.from_config(
+                KaiConfigModels(provider="FakeListChatModel")
+            )
         )
         # no need to create another directory for this test as we are mainly
         # testing LLM flow
@@ -46,7 +48,7 @@ class TestReflectionAgent(unittest.TestCase):
         }
 
         self.reflection_agent = ReflectionAgent(
-            model_provider=ModelProvider(
+            model_provider=ModelProvider.from_config(
                 config=KaiConfigModels(
                     args={
                         "responses": responses.get(tc, []),


### PR DESCRIPTION
Closes #136 
Closes #350

I refactored `model_provider.py`, putting each `ModelProvider` into its own class. This will allow you to override certain model-specific functionality. For example, a custom LLM invoke for Bedrock (the main reason I refactored)

Bedrock will now continue to generate tokens even if `max_tokens` is reached. Look at the following Python script and attached logs:

```python
from langchain.globals import set_debug, set_verbose

from kai.kai_config import KaiConfigModels, SupportedModelProviders
from kai.llm_interfacing.model_provider import ModelProvider

set_verbose(True)
set_debug(True)

m = ModelProvider.from_config(
    config=KaiConfigModels(
        provider=SupportedModelProviders.CHAT_BEDROCK,
        args={"model_id": "us.anthropic.claude-3-5-sonnet-20241022-v2:0"},
    )
)

print(m.invoke("Generate a long poem. 10,000 words. It must be very long.").content)
```

[tester.log](https://github.com/user-attachments/files/18881971/tester.log)

Ugly langchain color codes aside, you can see how we do two requests now, resulting in one continuous poem at the end.

I tested locally with Amazon Bedrock and OpenAI, but I would like some assistance testing other providers to make sure I didn't mess anything else up.

Separately, we should probably think about how to integrate streaming into the project. It should be fairly straightforward now with the `Chatter` class. We can create a message with a separate `messageToken` and update it as we get more chunks. WDYT?