### PR TITLE
:bug: CollapsableErrors assume validation field values are empty

### DIFF
--- a/kai/reactive_codeplanner/task_runner/compiler/maven_validator.py
+++ b/kai/reactive_codeplanner/task_runner/compiler/maven_validator.py
@@ -228,6 +228,10 @@ class PackageDoesNotExistError(CollapsedMavenCompilerError):
     def remove_unused_fields(self) -> None:
         self.line = 0
         self.column = 0
+        # The only place to fix packages not found is the pom.xml
+        # Once the package is in the pom we will no longer have this
+        # error.
+        self.file = "pom.xml"
 
 
 @dataclass(eq=False)


### PR DESCRIPTION
* When doing comparison for collapsable errors, we assume that only the fields that matter are different, and everything else is reset.
* We were not reseting the column for collapsable errors, causing them to look different for both fuzzy match and equality.
* When it was unable to be solved, due to an error, we infinitly added parent task as a child task.

fixes #677 