### PR TITLE
:sparkles: Handle retries and ignored tasks by not adding children

### DIFF
--- a/.trunk/configs/custom-words.txt
+++ b/.trunk/configs/custom-words.txt
@@ -156,3 +156,4 @@ venv
 VLLM
 webassets
 webmvc
+shaofstring

--- a/kai/reactive_codeplanner/agent/maven_compiler_fix/api.py
+++ b/kai/reactive_codeplanner/agent/maven_compiler_fix/api.py
@@ -4,7 +4,7 @@ from typing import Optional
 from kai.reactive_codeplanner.agent.api import AgentRequest, AgentResult
 from kai.reactive_codeplanner.agent.reflection_agent import ReflectionTask
 from kai.reactive_codeplanner.task_manager.api import Task
-from kai.reactive_codeplanner.vfs.git_vfs import SpawningResult
+from kai.reactive_codeplanner.vfs.spawning_result import SpawningResult
 
 
 @dataclass

--- a/kai/reactive_codeplanner/task_manager/api.py
+++ b/kai/reactive_codeplanner/task_manager/api.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
+from kai.reactive_codeplanner.vfs.repo_context_snapshot import RepoContextSnapshot
+
 
 # NOTE(@JonahSussman): Why is this necessary when we have
 # `KaiRpcApplicationConfig`?
@@ -30,6 +32,9 @@ class Task:
     retry_count: int = 0
     max_retries: int = 3
     result: Optional["TaskResult"] = None
+    # Will be used by the task manager, to revert
+    # if/when we ignore this task
+    _snapshot_before_work: Optional[RepoContextSnapshot] = None
 
     _creation_counter = 0
 

--- a/kai/reactive_codeplanner/task_manager/task_manager.py
+++ b/kai/reactive_codeplanner/task_manager/task_manager.py
@@ -401,7 +401,7 @@ class TaskManager:
             self.rcm.reset(task._snapshot_before_work)
             chatter.get().chat_markdown(
                 f"Task {task.__class__.__name__} was not resolved. resetting repo state to before task was tried)"
-                f"<details><summary>Details</summary>\n{resolved_task.markdown()}</details>\n"
+                f"<details><summary>Details</summary>\n{task.markdown()}</details>\n"
             )
 
     def stop(self) -> None:

--- a/kai/reactive_codeplanner/task_manager/task_manager.py
+++ b/kai/reactive_codeplanner/task_manager/task_manager.py
@@ -222,6 +222,8 @@ class TaskManager:
                 continue
 
             logger.info("Yielding task: %s", task)
+            if not task._snapshot_before_work:
+                task._snapshot_before_work = self.rcm.snapshot
             yield task
             # If our depth is 0, we won't follow up on issues anyway
             # We do lose the ability to verify a solution worked, so
@@ -298,6 +300,10 @@ class TaskManager:
             for t in similar_tasks:
                 unprocessed_new_tasks.remove(t)
             self.handle_ignored_task(task)
+            # Once we have a retry or an ignored task, we should wait to add
+            # children until the task is completed.
+            # On ignored task, we now revert to the before snapshot work
+            return
         else:
             self.processed_tasks.add(task)
             logger.debug("Task %s processed successfully.", task)
@@ -390,6 +396,11 @@ class TaskManager:
             chatter.get().chat_markdown(
                 f"{task.__class__.__name__} was not resolved. Ignoring... ({task.retry_count}/{task.max_retries})"
                 f"<details><summary>Details</summary>\n{task.markdown()}</details>\n"
+            )
+            logger.info("ignoring task, reverting to pre-task snapshot")
+            self.rcm.reset(task._snapshot_before_work)
+            chatter.get().chat_simple(
+                f"Task {task} was not resolved. resetting repo state to before task was tried)"
             )
 
     def stop(self) -> None:

--- a/kai/reactive_codeplanner/task_manager/task_manager.py
+++ b/kai/reactive_codeplanner/task_manager/task_manager.py
@@ -399,8 +399,9 @@ class TaskManager:
             )
             logger.info("ignoring task, reverting to pre-task snapshot")
             self.rcm.reset(task._snapshot_before_work)
-            chatter.get().chat_simple(
-                f"Task {task} was not resolved. resetting repo state to before task was tried)"
+            chatter.get().chat_markdown(
+                f"Task {task.__class__.__name__} was not resolved. resetting repo state to before task was tried)"
+                f"<details><summary>Details</summary>\n{resolved_task.markdown()}</details>\n"
             )
 
     def stop(self) -> None:

--- a/kai/reactive_codeplanner/task_runner/analyzer_lsp/task_runner.py
+++ b/kai/reactive_codeplanner/task_runner/analyzer_lsp/task_runner.py
@@ -14,7 +14,8 @@ from kai.reactive_codeplanner.agent.reflection_agent import ReflectionTask
 from kai.reactive_codeplanner.task_manager.api import Task, TaskResult
 from kai.reactive_codeplanner.task_runner.analyzer_lsp.api import AnalyzerRuleViolation
 from kai.reactive_codeplanner.task_runner.api import TaskRunner
-from kai.reactive_codeplanner.vfs.git_vfs import RepoContextManager, SpawningResult
+from kai.reactive_codeplanner.vfs.git_vfs import RepoContextManager
+from kai.reactive_codeplanner.vfs.spawning_result import SpawningResult
 
 logger = get_logger(__name__)
 tracer = trace.get_tracer("analyzer_task_runner")

--- a/kai/reactive_codeplanner/task_runner/compiler/compiler_task_runner.py
+++ b/kai/reactive_codeplanner/task_runner/compiler/compiler_task_runner.py
@@ -22,7 +22,8 @@ from kai.reactive_codeplanner.task_runner.compiler.maven_validator import (
     SyntaxError,
     TypeMismatchError,
 )
-from kai.reactive_codeplanner.vfs.git_vfs import RepoContextManager, SpawningResult
+from kai.reactive_codeplanner.vfs.git_vfs import RepoContextManager
+from kai.reactive_codeplanner.vfs.spawning_result import SpawningResult
 
 logger = get_logger(__name__)
 tracer = trace.get_tracer("maven_compile_task_runner")

--- a/kai/reactive_codeplanner/vfs/git_vfs.py
+++ b/kai/reactive_codeplanner/vfs/git_vfs.py
@@ -1,239 +1,16 @@
 import argparse
-import functools
-import subprocess  # trunk-ignore(bandit/B404)
 import tempfile
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Optional
 
-from kai.constants import ENV
-from kai.logging.logging import TRACE, get_logger
+from kai.logging.logging import get_logger
 from kai.reactive_codeplanner.agent.api import AgentResult
-from kai.reactive_codeplanner.agent.reflection_agent import (
-    ReflectionAgent,
-    ReflectionTask,
-)
+from kai.reactive_codeplanner.agent.reflection_agent import ReflectionAgent
+from kai.reactive_codeplanner.vfs.repo_context_snapshot import RepoContextSnapshot
+from kai.reactive_codeplanner.vfs.spawning_result import SpawningResult
 
 log = get_logger(__name__)
-
-
-class SpawningResult(ABC):
-    @abstractmethod
-    def to_reflection_task(self) -> Optional[ReflectionTask]:
-        pass
-
-
-# NOTE: I'd like to use GitPython, but using custom a work-tree and git-dir with
-# it is too hard.
-@dataclass(frozen=True)
-class RepoContextSnapshot:
-    work_tree: Path  # project root
-    snapshot_work_dir: Path  # .kai directory where all the repos live
-    git_dir: Path
-    git_sha: str
-
-    parent: Optional["RepoContextSnapshot"] = None
-    children: list["RepoContextSnapshot"] = field(default_factory=list)
-
-    spawning_result: Optional[SpawningResult] = None
-
-    @functools.cached_property
-    def msg(self) -> str:
-        """
-        msg is derived from the commit message of the git_sha. Use
-        cached_property to maintain semblance of immutability.
-        """
-        returncode, stdout, stderr = self.git(
-            ["show", "-s", "--format=%B", self.git_sha]
-        )
-        if returncode != 0:
-            raise Exception(f"Failed to get commit message: {stderr}")
-
-        return stdout.strip()
-
-    @functools.cached_property
-    def parent_spawning_results(self) -> list[SpawningResult]:
-        """
-        Returns a list of spawning results from the parent snapshots, including
-        itself, in order from oldest to newest.
-        """
-
-        if not self.spawning_result:
-            return []
-
-        if self.parent is None:
-            return [self.spawning_result]
-
-        return self.parent.parent_spawning_results + [self.spawning_result]
-
-    @functools.cached_property
-    def lineage(self) -> list["RepoContextSnapshot"]:
-        """
-        Returns the lineage of the current snapshot, starting from the initial
-        commit. In order from oldest to newest.
-        """
-        lineage: list[RepoContextSnapshot] = [self]
-        parent = self.parent
-        while parent is not None:
-            lineage.append(parent)
-            parent = parent.parent
-
-        lineage.reverse()
-
-        return lineage
-
-    def git(
-        self, args: list[str], popen_kwargs: dict[str, Any] | None = None
-    ) -> tuple[int | Any, str, str]:
-        """
-        Execute a git command with the given arguments. Returns a tuple of the
-        return code, stdout, and stderr.
-        """
-        if popen_kwargs is None:
-            popen_kwargs = {}
-
-        GIT = [
-            "git",
-            "--git-dir",
-            str(self.git_dir),
-            "--work-tree",
-            str(self.work_tree),
-        ]
-        popen_kwargs = {
-            "cwd": self.work_tree,
-            "env": ENV,
-            "stdout": subprocess.PIPE,
-            "stderr": subprocess.PIPE,
-            "text": True,
-            **popen_kwargs,
-        }
-
-        log.log(TRACE, "executing: " + " ".join(GIT + args))
-        proc = subprocess.Popen(GIT + args, **popen_kwargs)  # trunk-ignore(bandit/B603)
-        stdout, stderr = proc.communicate()
-
-        log.log(TRACE, f"returncode: {proc.returncode}")
-        log.log(TRACE, f"stdout:\n{stdout}")
-        log.log(TRACE, f"stderr:\n{stderr}")
-
-        return proc.returncode, stdout, stderr
-
-    @staticmethod
-    def initialize(
-        git_work_tree: Path, snapshot_work_dir: Path, msg: str | None = None
-    ) -> "RepoContextSnapshot":
-        """
-        Creates a new git repo in the given work_tree, and returns a
-        GitVFSSnapshot.
-        """
-        if msg is None:
-            msg = "Initial commit"
-
-        git_work_tree = git_work_tree.resolve()
-        snapshot_work_dir.mkdir(exist_ok=True)
-        # fmt: off
-        # Note that windows can not use : characters in the filename/path, Black doesn't like this syntax on 3.11
-        git_dir_suffix = datetime.now(timezone.utc).strftime("%Y-%m-%d-_%H-%M-%S")
-        git_dir = snapshot_work_dir / f".git-{git_dir_suffix}"
-        # fmt: on
-        git_dir.mkdir(exist_ok=True)
-
-        # Snapshot is immutable, so we create a temporary snapshot to get the
-        # git sha of the initial commit
-        tmp_snapshot = RepoContextSnapshot(
-            work_tree=git_work_tree,
-            snapshot_work_dir=snapshot_work_dir,
-            git_dir=git_dir,
-            git_sha="",
-        )
-
-        returncode, _, stderr = tmp_snapshot.git(["init"])
-        if returncode != 0:
-            raise Exception(f"Failed to initialize git repository: {stderr}")
-
-        with open(git_dir / "info" / "exclude", "a") as f:
-            f.write(f"/{str(snapshot_work_dir.name)}\n")
-
-        returncode, _, stderr = tmp_snapshot.git(["config", "commit.gpgsign", "false"])
-        if returncode != 0:
-            raise Exception(f"Failed to disable gpgsign: {stderr}")
-
-        returncode, _, stderr = tmp_snapshot.git(
-            ["config", "user.email", "kai-agent@example.com"]
-        )
-        if returncode != 0:
-            raise Exception(f"Failed to set user.email: {stderr}")
-        returncode, _, stderr = tmp_snapshot.git(["config", "user.name", "KaiAgent"])
-        if returncode != 0:
-            raise Exception(f"Failed to set user.name: {stderr}")
-
-        tmp_snapshot = tmp_snapshot.commit(msg)
-
-        return RepoContextSnapshot(
-            work_tree=git_work_tree,
-            snapshot_work_dir=snapshot_work_dir,
-            git_dir=git_dir,
-            git_sha=tmp_snapshot.git_sha,
-            parent=None,
-            children=[],
-        )
-
-    def commit(
-        self, msg: str | None = None, spawning_result: SpawningResult | None = None
-    ) -> "RepoContextSnapshot":
-        """
-        Commits the current state of the repository and returns a new snapshot.
-        Automatically sets the commit message to the current time if none is
-        provided. The children and parent fields are updated accordingly.
-        """
-        if msg is None:
-            msg = f"Auto-generated commit message ({datetime.now(timezone.utc).isoformat()})"
-
-        returncode, stdout, stderr = self.git(["add", "."])
-        if returncode != 0:
-            raise Exception(f"Failed to add files to git repository: {stderr}")
-
-        returncode, _, stderr = self.git(
-            ["commit", "--allow-empty", "--allow-empty-message", "-m", msg]
-        )
-        if returncode != 0:
-            raise Exception(f"Failed to create commit: {stderr}")
-
-        returncode, stdout, stderr = self.git(["rev-parse", "HEAD"])
-        if returncode != 0:
-            raise Exception(f"Failed to get HEAD: {stderr}")
-
-        result = RepoContextSnapshot(
-            work_tree=self.work_tree,
-            snapshot_work_dir=self.snapshot_work_dir,
-            git_dir=self.git_dir,
-            git_sha=stdout.strip(),
-            parent=self,
-            spawning_result=spawning_result,
-        )
-
-        self.children.append(result)
-
-        return result
-
-    def reset(self) -> tuple[int, str, str]:
-        """
-        Reset the state of the repository to the current snapshot.
-        """
-        return self.git(["reset", "--hard", self.git_sha])
-
-    def diff(self, other: "RepoContextSnapshot") -> tuple[int, str, str]:
-        """
-        Returns the diff between the current snapshot and another snapshot.
-        """
-        result = self.git(["diff", other.git_sha, self.git_sha])
-        if not result[1].endswith("\n"):  # HACK: This may not be needed
-            result = result[0], result[1] + "\n", result[2]
-
-        return result
 
 
 class RepoContextManager:
@@ -281,13 +58,13 @@ class RepoContextManager:
                             reflection_task
                         )
 
-            new_spawning_result = union_the_result_and_the_errors(
+            union_the_result_and_the_errors(
                 reflection_result.encountered_errors, spawning_result
             )
         else:
-            new_spawning_result = spawning_result
+            pass
 
-        self.snapshot = self.snapshot.commit(msg, new_spawning_result)
+        self.snapshot = self.snapshot.commit(msg)
 
         return True
 

--- a/kai/reactive_codeplanner/vfs/repo_context_snapshot.py
+++ b/kai/reactive_codeplanner/vfs/repo_context_snapshot.py
@@ -1,0 +1,204 @@
+import functools
+import subprocess  # trunk-ignore(bandit/B404)
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from kai.constants import ENV
+from kai.logging.logging import TRACE, get_logger
+
+log = get_logger(__name__)
+
+
+# NOTE: I'd like to use GitPython, but using custom a work-tree and git-dir with
+# it is too hard.
+@dataclass(frozen=True)
+class RepoContextSnapshot:
+    work_tree: Path  # project root
+    snapshot_work_dir: Path  # .kai directory where all the repos live
+    git_dir: Path
+    git_sha: str
+
+    parent: Optional["RepoContextSnapshot"] = None
+    children: list["RepoContextSnapshot"] = field(default_factory=list)
+
+    @functools.cached_property
+    def msg(self) -> str:
+        """
+        msg is derived from the commit message of the git_sha. Use
+        cached_property to maintain semblance of immutability.
+        """
+        returncode, stdout, stderr = self.git(
+            ["show", "-s", "--format=%B", self.git_sha]
+        )
+        if returncode != 0:
+            raise Exception(f"Failed to get commit message: {stderr}")
+
+        return stdout.strip()
+
+    @functools.cached_property
+    def lineage(self) -> list["RepoContextSnapshot"]:
+        """
+        Returns the lineage of the current snapshot, starting from the initial
+        commit. In order from oldest to newest.
+        """
+        lineage: list[RepoContextSnapshot] = [self]
+        parent = self.parent
+        while parent is not None:
+            lineage.append(parent)
+            parent = parent.parent
+
+        lineage.reverse()
+
+        return lineage
+
+    def git(
+        self, args: list[str], popen_kwargs: dict[str, Any] | None = None
+    ) -> tuple[int | Any, str, str]:
+        """
+        Execute a git command with the given arguments. Returns a tuple of the
+        return code, stdout, and stderr.
+        """
+        if popen_kwargs is None:
+            popen_kwargs = {}
+
+        GIT = [
+            "git",
+            "--git-dir",
+            str(self.git_dir),
+            "--work-tree",
+            str(self.work_tree),
+        ]
+        popen_kwargs = {
+            "cwd": self.work_tree,
+            "env": ENV,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": True,
+            **popen_kwargs,
+        }
+
+        log.log(TRACE, "executing: " + " ".join(GIT + args))
+        proc = subprocess.Popen(GIT + args, **popen_kwargs)  # trunk-ignore(bandit/B603)
+        stdout, stderr = proc.communicate()
+
+        log.log(TRACE, f"returncode: {proc.returncode}")
+        log.log(TRACE, f"stdout:\n{stdout}")
+        log.log(TRACE, f"stderr:\n{stderr}")
+
+        return proc.returncode, stdout, stderr
+
+    @staticmethod
+    def initialize(
+        git_work_tree: Path, snapshot_work_dir: Path, msg: str | None = None
+    ) -> "RepoContextSnapshot":
+        """
+        Creates a new git repo in the given work_tree, and returns a
+        GitVFSSnapshot.
+        """
+        if msg is None:
+            msg = "Initial commit"
+
+        git_work_tree = git_work_tree.resolve()
+        snapshot_work_dir.mkdir(exist_ok=True)
+        # fmt: off
+        # Note that windows can not use : characters in the filename/path, Black doesn't like this syntax on 3.11
+        git_dir_suffix = datetime.now(timezone.utc).strftime("%Y-%m-%d-_%H-%M-%S")
+        git_dir = snapshot_work_dir / f".git-{git_dir_suffix}"
+        # fmt: on
+        git_dir.mkdir(exist_ok=True)
+
+        # Snapshot is immutable, so we create a temporary snapshot to get the
+        # git sha of the initial commit
+        tmp_snapshot = RepoContextSnapshot(
+            work_tree=git_work_tree,
+            snapshot_work_dir=snapshot_work_dir,
+            git_dir=git_dir,
+            git_sha="",
+        )
+
+        returncode, _, stderr = tmp_snapshot.git(["init"])
+        if returncode != 0:
+            raise Exception(f"Failed to initialize git repository: {stderr}")
+
+        with open(git_dir / "info" / "exclude", "a") as f:
+            f.write(f"/{str(snapshot_work_dir.name)}\n")
+
+        returncode, _, stderr = tmp_snapshot.git(["config", "commit.gpgsign", "false"])
+        if returncode != 0:
+            raise Exception(f"Failed to disable gpgsign: {stderr}")
+
+        returncode, _, stderr = tmp_snapshot.git(
+            ["config", "user.email", "kai-agent@example.com"]
+        )
+        if returncode != 0:
+            raise Exception(f"Failed to set user.email: {stderr}")
+        returncode, _, stderr = tmp_snapshot.git(["config", "user.name", "KaiAgent"])
+        if returncode != 0:
+            raise Exception(f"Failed to set user.name: {stderr}")
+
+        tmp_snapshot = tmp_snapshot.commit(msg)
+
+        return RepoContextSnapshot(
+            work_tree=git_work_tree,
+            snapshot_work_dir=snapshot_work_dir,
+            git_dir=git_dir,
+            git_sha=tmp_snapshot.git_sha,
+            parent=None,
+            children=[],
+        )
+
+    def commit(
+        self,
+        msg: str | None = None,
+    ) -> "RepoContextSnapshot":
+        """
+        Commits the current state of the repository and returns a new snapshot.
+        Automatically sets the commit message to the current time if none is
+        provided. The children and parent fields are updated accordingly.
+        """
+        if msg is None:
+            msg = f"Auto-generated commit message ({datetime.now(timezone.utc).isoformat()})"
+
+        returncode, stdout, stderr = self.git(["add", "."])
+        if returncode != 0:
+            raise Exception(f"Failed to add files to git repository: {stderr}")
+
+        returncode, _, stderr = self.git(
+            ["commit", "--allow-empty", "--allow-empty-message", "-m", msg]
+        )
+        if returncode != 0:
+            raise Exception(f"Failed to create commit: {stderr}")
+
+        returncode, stdout, stderr = self.git(["rev-parse", "HEAD"])
+        if returncode != 0:
+            raise Exception(f"Failed to get HEAD: {stderr}")
+
+        result = RepoContextSnapshot(
+            work_tree=self.work_tree,
+            snapshot_work_dir=self.snapshot_work_dir,
+            git_dir=self.git_dir,
+            git_sha=stdout.strip(),
+            parent=self,
+        )
+
+        self.children.append(result)
+
+        return result
+
+    def reset(self) -> tuple[int, str, str]:
+        """
+        Reset the state of the repository to the current snapshot.
+        """
+        return self.git(["reset", "--hard", self.git_sha])
+
+    def diff(self, other: "RepoContextSnapshot") -> tuple[int, str, str]:
+        """
+        Returns the diff between the current snapshot and another snapshot.
+        """
+        result = self.git(["diff", other.git_sha, self.git_sha])
+        if not result[1].endswith("\n"):  # HACK: This may not be needed
+            result = result[0], result[1] + "\n", result[2]
+
+        return result

--- a/kai/reactive_codeplanner/vfs/spawning_result.py
+++ b/kai/reactive_codeplanner/vfs/spawning_result.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from kai.reactive_codeplanner.agent.reflection_agent import ReflectionTask
+
+
+class SpawningResult(ABC):
+    @abstractmethod
+    def to_reflection_task(self) -> Optional[ReflectionTask]:
+        pass

--- a/kai/rpc_server/server.py
+++ b/kai/rpc_server/server.py
@@ -50,7 +50,8 @@ from kai.reactive_codeplanner.task_runner.compiler.maven_validator import (
 from kai.reactive_codeplanner.task_runner.dependency.task_runner import (
     DependencyTaskRunner,
 )
-from kai.reactive_codeplanner.vfs.git_vfs import RepoContextManager, RepoContextSnapshot
+from kai.reactive_codeplanner.vfs.git_vfs import RepoContextManager
+from kai.reactive_codeplanner.vfs.repo_context_snapshot import RepoContextSnapshot
 from kai.rpc_server.chat import Chatter, get_chatter_contextvar
 
 tracer = trace.get_tracer("kai_application")
@@ -402,11 +403,6 @@ class GitVFSUpdateParams(BaseModel):
         else:
             diff = ""
 
-        try:
-            spawning_result = repr(snapshot.spawning_result)
-        except Exception:
-            spawning_result = ""
-
         return cls(
             work_tree=str(snapshot.work_tree),
             git_dir=str(snapshot.git_dir),
@@ -414,7 +410,7 @@ class GitVFSUpdateParams(BaseModel):
             diff=diff,
             msg=snapshot.msg,
             children=[cls.from_snapshot(c) for c in snapshot.children],
-            spawning_result=spawning_result,
+            spawning_result=None,
         )
 
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -13,6 +13,7 @@ from kai.reactive_codeplanner.task_manager.api import (
 )
 from kai.reactive_codeplanner.task_manager.task_manager import TaskManager
 from kai.reactive_codeplanner.vfs.git_vfs import RepoContextManager
+from kai.reactive_codeplanner.vfs.repo_context_snapshot import RepoContextSnapshot
 
 
 class MockValidationStep(ValidationStep):
@@ -42,6 +43,17 @@ class MockTaskRunner:
         return TaskResult(encountered_errors=[], modified_files=[], summary="")
 
 
+class MockRCM:
+    snapshot: RepoContextSnapshot
+    reset_snapshot: RepoContextSnapshot
+
+    def __init__(self, snapshot: RepoContextSnapshot):
+        self.snapshot = snapshot
+
+    def reset(self, snapshot: RepoContextSnapshot):
+        self.reset_snapshot = snapshot
+
+
 class TestTaskManager(unittest.TestCase):
     def test_simple_task_execution_order(self) -> None:
         # Setup
@@ -54,9 +66,14 @@ class TestTaskManager(unittest.TestCase):
                 [],  # Second run, no errors
             ],
         )
+        rcm = MockRCM(
+            RepoContextSnapshot(
+                Path("test"), Path("test-2"), Path("test-3"), "shaofstring"
+            )
+        )
         task_manager = TaskManager(
             config=None,
-            rcm=None,
+            rcm=rcm,
             validators=[validator],
             task_runners=[MockTaskRunner()],
         )
@@ -92,9 +109,14 @@ class TestTaskManager(unittest.TestCase):
                 [child2],  # Third run, no new errors
             ],
         )
+        rcm = MockRCM(
+            RepoContextSnapshot(
+                Path("test"), Path("test-2"), Path("test-3"), "shaofstring"
+            )
+        )
         task_manager = TaskManager(
             config=None,
-            rcm=None,
+            rcm=rcm,
             validators=[validator],
             task_runners=[MockTaskRunner()],
         )
@@ -141,9 +163,14 @@ class TestTaskManager(unittest.TestCase):
                 [],  # Fifth run, error resolved
             ],
         )
+        rcm = MockRCM(
+            RepoContextSnapshot(
+                Path("test"), Path("test-2"), Path("test-3"), "shaofstring"
+            )
+        )
         task_manager = TaskManager(
             config=None,
-            rcm=None,
+            rcm=rcm,
             validators=[validator],
             task_runners=[MockTaskRunner()],
         )
@@ -193,9 +220,14 @@ class TestTaskManager(unittest.TestCase):
                 ],  # Fifth run
             ],
         )
+        rcm = MockRCM(
+            RepoContextSnapshot(
+                Path("test"), Path("test-2"), Path("test-3"), "shaofstring"
+            )
+        )
         task_manager = TaskManager(
             config=None,
-            rcm=None,
+            rcm=rcm,
             validators=[validator],
             task_runners=[MockTaskRunner()],
         )
@@ -207,6 +239,7 @@ class TestTaskManager(unittest.TestCase):
         ignored_task = task_manager.ignored_tasks[0]
         self.assertEqual(ignored_task.message, "UnresolvableError")
         self.assertEqual(ignored_task.retry_count, ignored_task.max_retries)
+        self.assertEqual(rcm.snapshot, rcm.reset_snapshot)
 
     def test_complex_task_tree(self) -> None:
 
@@ -238,9 +271,14 @@ class TestTaskManager(unittest.TestCase):
                 [],  # Sixth run, no errors
             ],
         )
+        rcm = MockRCM(
+            RepoContextSnapshot(
+                Path("test"), Path("test-2"), Path("test-3"), "shaofstring"
+            )
+        )
         task_manager = TaskManager(
             config=None,
-            rcm=None,
+            rcm=rcm,
             validators=[validator],
             task_runners=[MockTaskRunner()],
         )
@@ -313,9 +351,14 @@ class TestTaskManager(unittest.TestCase):
                 message="ParentError",
             )
         ]
+        rcm = MockRCM(
+            RepoContextSnapshot(
+                Path("test"), Path("test-2"), Path("test-3"), "shaofstring"
+            )
+        )
         task_manager = TaskManager(
             config=None,
-            rcm=None,
+            rcm=rcm,
             seed_tasks=seed_tasks,
             validators=[validator],
             task_runners=[MockTaskRunner()],
@@ -366,9 +409,14 @@ class TestTaskManager(unittest.TestCase):
                 [],  # Fifth run, no errors
             ],
         )
+        rcm = MockRCM(
+            RepoContextSnapshot(
+                Path("test"), Path("test-2"), Path("test-3"), "shaofstring"
+            )
+        )
         task_manager = TaskManager(
             config=None,
-            rcm=None,
+            rcm=rcm,
             validators=[validator],
             task_runners=[MockTaskRunner()],
         )


### PR DESCRIPTION
* This will short circut the handling of a task when it is ignored to not add children
* Also added the logic to on moving a task to ignored, we revert the repo back to the state it was in when the task started.
* Had to remove the spawning result history from RepoContextSnapshot because of cycle imports of task -> RCS -> SpawningResult -> ReflectionTask -> task.