### PR TITLE
👻  Validated tool usage with different providers

### DIFF
--- a/.github/workflows/build-and-push-binaries.yml
+++ b/.github/workflows/build-and-push-binaries.yml
@@ -35,7 +35,7 @@ on:
 env:
   BUILD_MATRIX: | 
     [ 
-      { "os": "ubuntu-20.04", "shell": "bash" },
+      { "os": "ubuntu-24.04", "shell": "bash" },
       { "os": "macos-latest", "shell": "bash" },
       { "os": "macos-13", "shell": "bash" },
       { "os": "ubuntu-22.04-arm", "shell": "bash" },

--- a/notebooks/followup_agent/00_do_followup_work.ipynb
+++ b/notebooks/followup_agent/00_do_followup_work.ipynb
@@ -350,6 +350,277 @@
     "\n",
     "![beans_removal](./screenshots/beans_xml_removal.png)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Validating tool usage with different providers via Model Provider\n",
+    "\n",
+    "This section validates that we are able to use tools with different Model Providers we support."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.tools import tool\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "from langchain_core.language_models import LanguageModelLike\n",
+    "\n",
+    "@tool\n",
+    "def get_temperature(city: Annotated[str, \"Name of the city\"]):\n",
+    "    \"\"\"Returns current temperature in given city\"\"\"\n",
+    "    return f\"Current temperature in {city} is 80 degrees.\"\n",
+    "\n",
+    "def validate(model: LanguageModelLike, **kwargs):\n",
+    "    agent = create_react_agent(\n",
+    "        model=model,\n",
+    "        tools=[get_temperature],\n",
+    "        prompt=\"Help the user with their queries, use the tools at your disposal.\",\n",
+    "        **kwargs,\n",
+    "    )\n",
+    "\n",
+    "    for r in agent.stream({\"messages\": [(\"user\", \"What is the current temperature in New York?\")]}):\n",
+    "        print(r)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Depending on which model you test this with, you need to set up your API keys for the model before running the \"validation\" cell. Every cell has a comment at top about the environment variable expected.\n",
+    "\n",
+    "You will set the keys in `.env` file at the project root and run the following cell for changes to take effect."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Results\n",
+    "\n",
+    "|   Kai Model Provider   |      Model       |  Works?  |\n",
+    "| ---------------------- | ---------------- | -------- |\n",
+    "| ChatOpenAI             | gpt-3.5-turbo    |  &check; |\n",
+    "| ChatOpenAI (RH Maas)   | granite-8b       |  &check; |\n",
+    "| ChatBedrock            | llama-70b-v1     |  &cross; |\n",
+    "| ChatBedrock            | llama-70b-v2     |  &cross; |\n",
+    "| ChatBedrock            | claude-3-sonnet  |  &check; |\n",
+    "| ChatGoogleGenAI        | gemini-2.0-flash |  &check; |\n",
+    "| ChatDeepSeek           | deepseek-chat    |  &check; |\n",
+    "\n",
+    "Following model providers are not tested yet:\n",
+    "\n",
+    "* ChatOllama\n",
+    "* ChatAzureOpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'chatcmpl-tool-93d38e3ef7764368aeab44edfa14db42', 'function': {'arguments': '{\"city\": \"New York\"}', 'name': 'get_temperature'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 25, 'prompt_tokens': 140, 'total_tokens': 165, 'completion_tokens_details': None, 'prompt_tokens_details': None}, 'model_name': 'granite-3-8b-instruct', 'system_fingerprint': None, 'finish_reason': 'tool_calls', 'logprobs': None}, id='run-97df9c64-fad3-4df2-b314-76b4fc50324e-0', tool_calls=[{'name': 'get_temperature', 'args': {'city': 'New York'}, 'id': 'chatcmpl-tool-93d38e3ef7764368aeab44edfa14db42', 'type': 'tool_call'}], usage_metadata={'input_tokens': 140, 'output_tokens': 25, 'total_tokens': 165, 'input_token_details': {}, 'output_token_details': {}})]}}\n",
+      "{'tools': {'messages': [ToolMessage(content='Current temperature in New York is 80 degrees.', name='get_temperature', id='92aee6a7-fc0c-4137-991f-dfbdbd915f92', tool_call_id='chatcmpl-tool-93d38e3ef7764368aeab44edfa14db42')]}}\n",
+      "{'agent': {'messages': [AIMessage(content='The current temperature in New York is 80 degrees.', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 13, 'prompt_tokens': 161, 'total_tokens': 174, 'completion_tokens_details': None, 'prompt_tokens_details': None}, 'model_name': 'granite-3-8b-instruct', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-efec3793-40ed-4125-96ea-8dfdb247961a-0', usage_metadata={'input_tokens': 161, 'output_tokens': 13, 'total_tokens': 174, 'input_token_details': {}, 'output_token_details': {}})]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Test with granite-8b on RH maas via ChatOpenAI\n",
+    "## Env vars needed:\n",
+    "## PARASOL_GRANITE_KEY - api key\n",
+    "## PARASON_GRANITE_API - base url (usually ends with /v1)\n",
+    "\n",
+    "from kai.llm_interfacing.model_provider import ChatOpenAI\n",
+    "\n",
+    "validate(ChatOpenAI(\n",
+    "    api_key=os.environ[\"PARASOL_GRANITE_KEY\"],\n",
+    "    base_url=os.environ[\"PARASOL_GRANITE_API\"],\n",
+    "    model_name=\"granite-3-8b-instruct\",\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_hyQWUzmMBoWcy7lgjdtKMqKK', 'function': {'arguments': '{\"city\":\"New York\"}', 'name': 'get_temperature'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 16, 'prompt_tokens': 75, 'total_tokens': 91, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-3.5-turbo-0125', 'system_fingerprint': None, 'finish_reason': 'tool_calls', 'logprobs': None}, id='run-ef88bd74-8e49-47b8-a583-ad33145a439f-0', tool_calls=[{'name': 'get_temperature', 'args': {'city': 'New York'}, 'id': 'call_hyQWUzmMBoWcy7lgjdtKMqKK', 'type': 'tool_call'}], usage_metadata={'input_tokens': 75, 'output_tokens': 16, 'total_tokens': 91, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
+      "{'tools': {'messages': [ToolMessage(content='Current temperature in New York is 80 degrees.', name='get_temperature', id='7339a847-6267-4964-8f81-0c3ca9a3c4e0', tool_call_id='call_hyQWUzmMBoWcy7lgjdtKMqKK')]}}\n",
+      "{'agent': {'messages': [AIMessage(content='The current temperature in New York is 80 degrees.', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 13, 'prompt_tokens': 108, 'total_tokens': 121, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-3.5-turbo-0125', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-176cd009-bd24-40c6-be5c-dd29a95bfd59-0', usage_metadata={'input_tokens': 108, 'output_tokens': 13, 'total_tokens': 121, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Test with gpt-3.5-turbo via ChatOpenAI\n",
+    "## Env vars needed:\n",
+    "## OPENAI_API_KEY - api key\n",
+    "\n",
+    "validate(ChatOpenAI(\n",
+    "    model=\"gpt-3.5-turbo\"\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'function_call': {'name': 'get_temperature', 'arguments': '{\"city\": \"New York\"}'}}, response_metadata={'prompt_feedback': {'block_reason': 0, 'safety_ratings': []}, 'finish_reason': 'STOP', 'safety_ratings': []}, id='run-0345ec89-e933-4a1a-9645-ca54d4a3d3b6-0', tool_calls=[{'name': 'get_temperature', 'args': {'city': 'New York'}, 'id': '84239db4-b642-4c92-9a83-ec759f341dff', 'type': 'tool_call'}], usage_metadata={'input_tokens': 38, 'output_tokens': 6, 'total_tokens': 44, 'input_token_details': {'cache_read': 0}})]}}\n",
+      "{'tools': {'messages': [ToolMessage(content='Current temperature in New York is 80 degrees.', name='get_temperature', id='5ed17fd0-c2b7-4f5a-9449-0c1287060c19', tool_call_id='84239db4-b642-4c92-9a83-ec759f341dff')]}}\n",
+      "{'agent': {'messages': [AIMessage(content='The current temperature in New York is 80 degrees.', additional_kwargs={}, response_metadata={'prompt_feedback': {'block_reason': 0, 'safety_ratings': []}, 'finish_reason': 'STOP', 'safety_ratings': []}, id='run-9e6ccb8d-9110-4cee-94db-a6085ffffed8-0', usage_metadata={'input_tokens': 59, 'output_tokens': 13, 'total_tokens': 72, 'input_token_details': {'cache_read': 0}})]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Test with gemini-2.0-flash via GoogleGenAI\n",
+    "## Env vars needed:\n",
+    "## GEMINI_API_KEY - api key\n",
+    "\n",
+    "from kai.llm_interfacing.model_provider import ChatGoogleGenerativeAI\n",
+    "\n",
+    "validate(ChatGoogleGenerativeAI(\n",
+    "    api_key=os.environ[\"GEMINI_API_KEY\"],\n",
+    "    model=\"gemini-2.0-flash\",\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content=\"I'm just an AI, I don't have access to real-time weather data. However, I can suggest some ways for you to find out the current temperature in New York:\\n\\n1. Check online weather websites: You can check websites like AccuWeather, Weather.com, or the National Weather Service (NWS) for the current temperature in New York.\\n2. Use a weather app: You can download a weather app on your smartphone, such as Dark Sky or Weather Underground, which can provide you with real-time weather information, including the current temperature.\\n3. Check social media: Many weather organizations and meteorologists share current weather conditions, including temperature, on social media platforms like Twitter and Facebook.\\n4. Tune into local news: You can watch local news or listen to local radio stations to get the current temperature and weather forecast for New York.\\n\\nPlease note that the temperature can change rapidly, so it's always a good idea to check multiple sources for the most up-to-date information.\", additional_kwargs={'usage': {'prompt_tokens': 39, 'completion_tokens': 200, 'total_tokens': 239}, 'stop_reason': 'stop', 'model_id': 'us.meta.llama3-1-70b-instruct-v1:0'}, response_metadata={'usage': {'prompt_tokens': 39, 'completion_tokens': 200, 'total_tokens': 239}, 'stop_reason': 'stop', 'model_id': 'us.meta.llama3-1-70b-instruct-v1:0'}, id='run-e5b9bdad-42ca-4706-87d3-45b911b4d674-0', usage_metadata={'input_tokens': 39, 'output_tokens': 200, 'total_tokens': 239})]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Test with llama-70b via Bedrock\n",
+    "## Env vars needed:\n",
+    "## AWS_ACCESS_KEY_ID\n",
+    "## AWS_SECRET_ACCESS_KEY\n",
+    "\n",
+    "from kai.llm_interfacing.model_provider import ChatBedrock\n",
+    "\n",
+    "validate(ChatBedrock(\n",
+    "    model=\"us.meta.llama3-1-70b-instruct-v1:0\"\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content=\"I'm just an AI, I don't have real-time access to current weather conditions. However, I can suggest some ways for you to find out the current temperature in New York.\\n\\nYou can check the current weather forecast for New York on websites like:\\n\\n* National Weather Service (NWS) - [www.weather.gov](http://www.weather.gov)\\n* AccuWeather - [www.accuweather.com](http://www.accuweather.com)\\n* Weather.com - [www.weather.com](http://www.weather.com)\\n* Google Maps - [maps.google.com](http://maps.google.com) (look for the weather icon)\\n\\nYou can also check your local news or weather app on your smartphone for the current temperature in New York.\\n\\nIf you're looking for a more specific answer, I can try to help you with that. What city in New York are you looking for the temperature in?\", additional_kwargs={'usage': {'prompt_tokens': 39, 'completion_tokens': 182, 'total_tokens': 221}, 'stop_reason': 'stop', 'model_id': 'us.meta.llama3-2-1b-instruct-v1:0'}, response_metadata={'usage': {'prompt_tokens': 39, 'completion_tokens': 182, 'total_tokens': 221}, 'stop_reason': 'stop', 'model_id': 'us.meta.llama3-2-1b-instruct-v1:0'}, id='run-43bcbfbb-00fb-4616-ab8b-b1aaadee2f32-0', usage_metadata={'input_tokens': 39, 'output_tokens': 182, 'total_tokens': 221})]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "validate(ChatBedrock(\n",
+    "    model=\"us.meta.llama3-2-1b-instruct-v1:0\",\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content='I\\'m just an AI, I don\\'t have access to real-time information, but I can suggest some ways for you to find the current temperature in New York.\\n\\nYou can check the current temperature in New York by:\\n\\n1. Checking online weather websites such as AccuWeather, Weather.com, or the National Weather Service (NWS) website.\\n2. Using a mobile app like Dark Sky or Weather Underground.\\n3. Searching for \"current temperature in New York\" on a search engine like Google.\\n4. Checking the website of a local news station or newspaper in New York.\\n\\nPlease note that the temperature can vary depending on the location within New York, so it\\'s a good idea to check the temperature for a specific location, such as Manhattan, Brooklyn, or Queens.', additional_kwargs={'usage': {'prompt_tokens': 40, 'completion_tokens': 157, 'total_tokens': 197}, 'stop_reason': 'stop', 'model_id': 'us.meta.llama3-3-70b-instruct-v1:0'}, response_metadata={'usage': {'prompt_tokens': 40, 'completion_tokens': 157, 'total_tokens': 197}, 'stop_reason': 'stop', 'model_id': 'us.meta.llama3-3-70b-instruct-v1:0'}, id='run-3d9cf880-c3f8-4fcf-a3ea-a873adb5d83e-0', usage_metadata={'input_tokens': 40, 'output_tokens': 157, 'total_tokens': 197})]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "validate(ChatBedrock(\n",
+    "    model=\"us.meta.llama3-3-70b-instruct-v1:0\"\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'usage': {'prompt_tokens': 253, 'completion_tokens': 54, 'total_tokens': 307}, 'stop_reason': 'tool_use', 'model_id': 'us.anthropic.claude-3-sonnet-20240229-v1:0'}, response_metadata={'usage': {'prompt_tokens': 253, 'completion_tokens': 54, 'total_tokens': 307}, 'stop_reason': 'tool_use', 'model_id': 'us.anthropic.claude-3-sonnet-20240229-v1:0'}, id='run-ebe41a8a-c51b-4c47-b222-b73af17499b4-0', tool_calls=[{'name': 'get_temperature', 'args': {'city': 'New York'}, 'id': 'toolu_bdrk_01ACM8hMxuQHJeGnbQLDqqgz', 'type': 'tool_call'}], usage_metadata={'input_tokens': 253, 'output_tokens': 54, 'total_tokens': 307})]}}\n",
+      "{'tools': {'messages': [ToolMessage(content='Current temperature in New York is 80 degrees.', name='get_temperature', id='51824bd5-9d8e-4e26-8795-603c48d155c6', tool_call_id='toolu_bdrk_01ACM8hMxuQHJeGnbQLDqqgz')]}}\n",
+      "{'agent': {'messages': [AIMessage(content='The current temperature in New York is 80 degrees Fahrenheit.', additional_kwargs={'usage': {'prompt_tokens': 329, 'completion_tokens': 19, 'total_tokens': 348}, 'stop_reason': 'end_turn', 'model_id': 'us.anthropic.claude-3-sonnet-20240229-v1:0'}, response_metadata={'usage': {'prompt_tokens': 329, 'completion_tokens': 19, 'total_tokens': 348}, 'stop_reason': 'end_turn', 'model_id': 'us.anthropic.claude-3-sonnet-20240229-v1:0'}, id='run-128488f9-58ac-4baf-99a8-41e9b40bf676-0', usage_metadata={'input_tokens': 329, 'output_tokens': 19, 'total_tokens': 348})]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "validate(ChatBedrock(\n",
+    "    model=\"us.anthropic.claude-3-sonnet-20240229-v1:0\",\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_0_1211c9dd-2ad1-43f3-8696-94c912284b06', 'function': {'arguments': '{\"city\":\"New York\"}', 'name': 'get_temperature'}, 'type': 'function', 'index': 0}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 20, 'prompt_tokens': 129, 'total_tokens': 149, 'completion_tokens_details': None, 'prompt_tokens_details': {'audio_tokens': None, 'cached_tokens': 128}, 'prompt_cache_hit_tokens': 128, 'prompt_cache_miss_tokens': 1}, 'model_name': 'deepseek-chat', 'system_fingerprint': 'fp_3a5770e1b4_prod0225', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run-06857c74-a5ef-4121-a4a5-590df9397845-0', tool_calls=[{'name': 'get_temperature', 'args': {'city': 'New York'}, 'id': 'call_0_1211c9dd-2ad1-43f3-8696-94c912284b06', 'type': 'tool_call'}], usage_metadata={'input_tokens': 129, 'output_tokens': 20, 'total_tokens': 149, 'input_token_details': {'cache_read': 128}, 'output_token_details': {}})]}}\n",
+      "{'tools': {'messages': [ToolMessage(content='Current temperature in New York is 80 degrees.', name='get_temperature', id='b4290fe8-05a3-474c-b7a9-5d005ec45cda', tool_call_id='call_0_1211c9dd-2ad1-43f3-8696-94c912284b06')]}}\n",
+      "{'__interrupt__': ()}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Env vars needed:\n",
+    "# DEEPSEEK_API_KEY\n",
+    "\n",
+    "from kai.llm_interfacing.model_provider import ChatDeepSeek\n",
+    "\n",
+    "validate(model=ChatDeepSeek(\n",
+    "    api_key=os.environ[\"DEEPSEEK_API_KEY\"],\n",
+    "    model=\"deepseek-chat\",\n",
+    "), interrupt_after=[\"tools\"])"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/followup_agent/00_do_followup_work.ipynb
+++ b/notebooks/followup_agent/00_do_followup_work.ipynb
@@ -406,6 +406,7 @@
     "| ---------------------- | ---------------- | -------- |\n",
     "| ChatOpenAI             | gpt-3.5-turbo    |  &check; |\n",
     "| ChatOpenAI (RH Maas)   | granite-8b       |  &check; |\n",
+    "| ChatOpenAI (RH Maas)   | llama-7b         |  &check; |\n",
     "| ChatBedrock            | llama-70b-v1     |  &cross; |\n",
     "| ChatBedrock            | llama-70b-v2     |  &cross; |\n",
     "| ChatBedrock            | claude-3-sonnet  |  &check; |\n",
@@ -420,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,6 +455,29 @@
     "    api_key=os.environ[\"PARASOL_GRANITE_KEY\"],\n",
     "    base_url=os.environ[\"PARASOL_GRANITE_API\"],\n",
     "    model_name=\"granite-3-8b-instruct\",\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'chatcmpl-tool-671b7256d3e94bed833385429a6d5168', 'function': {'arguments': '{\"city\": \"New York\"}', 'name': 'get_temperature'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 18, 'prompt_tokens': 206, 'total_tokens': 224, 'completion_tokens_details': None, 'prompt_tokens_details': None}, 'model_name': 'meta-llama/Llama-3.1-8B-Instruct', 'system_fingerprint': None, 'finish_reason': 'tool_calls', 'logprobs': None}, id='run-fe619e78-3d5f-4814-8a78-a4f9b24d9b7d-0', tool_calls=[{'name': 'get_temperature', 'args': {'city': 'New York'}, 'id': 'chatcmpl-tool-671b7256d3e94bed833385429a6d5168', 'type': 'tool_call'}], usage_metadata={'input_tokens': 206, 'output_tokens': 18, 'total_tokens': 224, 'input_token_details': {}, 'output_token_details': {}})]}}\n",
+      "{'tools': {'messages': [ToolMessage(content='Current temperature in New York is 80 degrees.', name='get_temperature', id='ba529951-2d5f-4a2c-82ef-1dcf4bbac5fd', tool_call_id='chatcmpl-tool-671b7256d3e94bed833385429a6d5168')]}}\n",
+      "{'agent': {'messages': [AIMessage(content=\"I used the hypothetical output of the function to create a sample response. However, in a real scenario, the function would return the actual temperature value as per the actual output of the 'get_temperature' function.\", additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 43, 'prompt_tokens': 249, 'total_tokens': 292, 'completion_tokens_details': None, 'prompt_tokens_details': None}, 'model_name': 'meta-llama/Llama-3.1-8B-Instruct', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-496d77f3-4914-46a8-90ac-225c3c7b2011-0', usage_metadata={'input_tokens': 249, 'output_tokens': 43, 'total_tokens': 292, 'input_token_details': {}, 'output_token_details': {}})]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "validate(ChatOpenAI(\n",
+    "    api_key=os.environ[\"PARASOL_LLAMA_KEY\"],\n",
+    "    base_url=os.environ[\"PARASOL_LLAMA_API\"],\n",
+    "    model_name=\"meta-llama/Llama-3.1-8B-Instruct\",\n",
     "))"
    ]
   },


### PR DESCRIPTION
Here are the results...ChatBedrock for llama models does NOT support tools. 

|   Kai Model Provider   |      Model       |  Works?  |
| ---------------------- | ---------------- | -------- |
| ChatOpenAI             | gpt-3.5-turbo    |  ✅  |
| ChatOpenAI (RH Maas)   | granite-8b       |  ✅  |
| ChatOpenAI (RH Maas)   | llama-3.1-8b      |  ✅  |
| ChatBedrock            | llama3-1-70b     |  ❌  |
| ChatBedrock            | llama3-2-70b     |  ❌ |
| ChatBedrock            | claude-3-sonnet  |  ✅  |
| ChatGoogleGenAI        | gemini-2.0-flash |  ✅  |
| ChatDeepSeek           | deepseek-chat    |  ✅  |

We have not tested the following providers yet:

* AzureChatOpenAI
* ChatOllama