### PR TITLE
:bug: Build solution-server image from the lockfile, not pyproject floors

### DIFF
--- a/kai_mcp_solution_server/tools/deploy/Containerfile
+++ b/kai_mcp_solution_server/tools/deploy/Containerfile
@@ -11,10 +11,17 @@ RUN dnf --refresh -y update \
 # Copy project files
 COPY src/ src/
 COPY pyproject.toml .
+COPY requirements.txt .
 COPY README.md .
 
-# Install Python dependencies
-RUN pip3.12 install --no-cache-dir .
+# Install Python dependencies from the pinned lockfile export, then the
+# package itself without re-resolving. Installing `.` alone resolves the
+# pyproject floors at build time, which let fastmcp drift onto 3.4.3 —
+# whose Host/Origin guard 421s every request behind an ingress proxy.
+# Pinning to requirements.txt (fastmcp==2.14.3, mcp==1.25.0, ...) keeps the
+# image reproducible and matches what the project actually tests against.
+RUN pip3.12 install --no-cache-dir -r requirements.txt \
+ && pip3.12 install --no-cache-dir --no-deps .
 
 # Create a non-root user
 RUN useradd -m mcp


### PR DESCRIPTION
## Summary

Fixes #934. The `kai-solution-server` image drifted onto **fastmcp 3.4.3**, whose `HostOriginGuardMiddleware` is enabled by default and returns `421 Misdirected Request` for every request whose `Host` header doesn't match — i.e. every request behind an ingress/route. This broke `editor-extensions` `@requires-minikube` CI and affects any proxied deployment.

### Root cause

[`kai_mcp_solution_server/tools/deploy/Containerfile`](https://github.com/konveyor/kai/blob/main/kai_mcp_solution_server/tools/deploy/Containerfile) installed the app with `pip install .`, which **resolves the `pyproject.toml` dependency floors at build time** (e.g. `fastmcp>=2.8.0`) and ignores the committed lock. `requirements.txt` / `uv.lock` pin `fastmcp==2.14.3`, `mcp==1.25.0`, `starlette==1.3.1`, but those pins never reached the image. So each `:latest` rebuild silently picked up the newest resolvable `fastmcp` — 3.4.3 once it published.

For reference, fastmcp **3.4.4** already flipped `http_host_origin_protection` back to `False` by default, but relying on that is just more floating-latest roulette; the image should install what the project locks.

### Fix

Install the pinned set from `requirements.txt` first, then the package itself with `--no-deps`:

```dockerfile
COPY requirements.txt .
...
RUN pip3.12 install --no-cache-dir -r requirements.txt \
 && pip3.12 install --no-cache-dir --no-deps .
```

This makes the image reproducible and match what the project actually tests against, and fixes the drift for **all** dependencies, not just fastmcp.

### Validation

I couldn't build the UBI image in this environment, but I verified the mechanical precondition for `--no-deps`: **every one of the 34 runtime dependencies declared in `pyproject.toml` is present in `requirements.txt`** (192 pinned packages), so `pip install --no-deps .` installs cleanly with nothing missing. A maintainer build + push of `:latest` is the final confirmation.

### Alternatives considered

- Capping `fastmcp>=2.8.0,<3` in `pyproject.toml` — smaller diff, but only patches this one dependency and leaves the image resolving every other floor at build time. Installing from the lock addresses the class of bug.